### PR TITLE
feat(http): add SSE event type support and improve buffer handling

### DIFF
--- a/bpf/mcpspy.c
+++ b/bpf/mcpspy.c
@@ -256,6 +256,12 @@ int BPF_URETPROBE(ssl_read_exit, int ret) {
         return 0;
     }
 
+    if (ret > MAX_BUF_SIZE) {
+        // We still want to deliver these messages for HTTP session integrity.
+        // But it means we'll may lose information.
+        bpf_printk("info: ssl_read_exit: buffer is too big: %d > %d", ret, MAX_BUF_SIZE);
+    }
+
     // Checking the session if was set to specific http version.
     // If not, we try to identify the version from the payload.
     __u64 ssl_ptr = params->ssl;
@@ -318,6 +324,12 @@ SEC("uprobe/SSL_write")
 int BPF_UPROBE(ssl_write_entry, void *ssl, const void *buf, int num) {
     if (num <= 0) {
         return 0;
+    }
+
+    if (num > MAX_BUF_SIZE) {
+        // We still want to deliver these messages for HTTP session integrity.
+        // But it means we'll may lose information.
+        bpf_printk("info: ssl_write_entry: buffer is too big: %d > %d", num, MAX_BUF_SIZE);
     }
 
     // Checking the session if was set to specific http version.
@@ -415,6 +427,12 @@ int BPF_URETPROBE(ssl_read_ex_exit, int ret) {
                        (const void *)params->readbytes);
     }
 
+    if (actual_read > MAX_BUF_SIZE) {
+        // We still want to deliver these messages for HTTP session integrity.
+        // But it means we'll may lose information.
+        bpf_printk("info: ssl_read_ex_exit: buffer is too big: %d > %d", actual_read, MAX_BUF_SIZE);
+    }
+
     // Checking the session if was set to specific http version.
     // If not, we try to identify the version from the payload.
     __u64 ssl_ptr = params->ssl;
@@ -475,6 +493,12 @@ int BPF_UPROBE(ssl_write_ex_entry, void *ssl, const void *buf, size_t num,
                size_t *written) {
     if (num <= 0) {
         return 0;
+    }
+
+    if (num > MAX_BUF_SIZE) {
+        // We still want to deliver these messages for HTTP session integrity.
+        // But it means we'll may lose information.
+        bpf_printk("info: ssl_write_ex_entry: buffer is too big: %d > %d", num, MAX_BUF_SIZE);
     }
 
     // Checking the session if was set to specific http version.

--- a/cmd/mcpspy/main.go
+++ b/cmd/mcpspy/main.go
@@ -202,9 +202,10 @@ func run(cmd *cobra.Command, args []string) error {
 				sseEvent := event.(*mcpevents.SSEEvent)
 
 				logrus.WithFields(logrus.Fields{
-					"method": sseEvent.Method,
-					"host":   sseEvent.Host,
-					"path":   sseEvent.Path,
+					"method":    sseEvent.Method,
+					"host":      sseEvent.Host,
+					"path":      sseEvent.Path,
+					"sse_event": sseEvent.SSEEventType,
 				}).Trace("HTTP SSE event")
 
 				// Parse SSE data as MCP messages

--- a/pkg/ebpf/loader.go
+++ b/pkg/ebpf/loader.go
@@ -138,7 +138,7 @@ func (l *Loader) Start(ctx context.Context) error {
 
 				// First, reading the first byte to get the event type
 				if len(record.RawSample) < 1 {
-					logrus.Warn("Received empty event. Can't be read the event type.")
+					logrus.Warn("Received empty event. Can't read the event type.")
 					continue
 				}
 

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -182,7 +182,9 @@ type SSEEvent struct {
 
 	SSLContext uint64 // SSL context pointer (session identifier)
 
-	// SSE data. Currently only 'data' is supported.
+	// SSE event type (e.g., "message", "update", etc.)
+	SSEEventType string
+	// SSE data
 	Data []byte
 }
 

--- a/pkg/mcp/parser.go
+++ b/pkg/mcp/parser.go
@@ -229,12 +229,12 @@ func (p *Parser) ParseDataStdio(data []byte, eventType event.EventType, pid uint
 			jsonRpcMsg, err := p.parseJSONRPC(jsonData)
 			if err != nil {
 				// No reason to keep iterating.
-				return []*Message{}, err
+				return nil, fmt.Errorf("failed to parse JSON-RPC: %w", err)
 			}
 
 			if ok, err := p.validateMCPMessage(jsonRpcMsg); !ok {
 				// No reason to keep iterating.
-				return []*Message{}, err
+				return nil, fmt.Errorf("invalid MCP message: %w", err)
 			}
 
 			// Create stdio transport info from correlated events


### PR DESCRIPTION
- Add SSEEventType field to SSEEvent struct for event categorization
- Update emitSSEEvent function to accept event type and data parameters
- Implement unified extractSSEEventData function for parsing SSE fields
- Enhance parseSSEEvents to handle all SSE fields instead of just data
- Add comprehensive test coverage for SSE event parsing and type extraction
- Include SSE event type in main.go logging output for better debugging
- Add buffer size validation with warnings in eBPF SSL hooks
- Improve error handling and logging consistency in MCP parser
- Convert debug warnings to appropriate log levels for production use

🤖 Generated with [Claude Code](https://claude.ai/code)