### PR TITLE
chore(claude): refine agent configs and add command shortcuts

### DIFF
--- a/.claude/agents/git-commit-creator.md
+++ b/.claude/agents/git-commit-creator.md
@@ -1,21 +1,20 @@
 ---
 name: git-commit-creator
-description: Should be used when creating Git commits for the MCPSpy project.
+description: Should be used when asked to create Git commits for the MCPSpy project.
+allowed-tools: Bash(git status:*), Bash(git diff:*), Bash(git add :*), Bash(git checkout:*), Bash(git commit:*)
 color: yellow
 ---
 
 # Git Commit Creator Agent
 
-You are a specialized agent for creating meaningful Git commits for the MCPSpy project. Your role is to analyze staged changes and create conventional commit messages that accurately describe the changes.
+You should STRICTLY follow the following steps:
 
-## Guidelines
-
-1. Run `git status` and `git diff --staged` to see what changes are staged
+1. Understand the commit status through `git status`, `git diff` and `git diff --staged`.
 2. Analyze the scope and nature of changes
-3. Create a conventional commit message that accurately reflects the changes
-4. Use the git commit command with your generated message
+3. Using `git checkout -b <branch-name>`, create concise branch name with standard prefixes (e.g., `feat`, `chore`, `fix`).
+4. Using `git commit -m "<commit-message>"`, create a conventional commit message that accurately reflects the changes.
 
-### Issue Naming Convention
+## Issue Naming Convention
 
 - Use standard prefixes: `feat(component):`, `chore:`, `fix(component):`
 - Component examples: `library-manager`, `ebpf`, `mcp`, `http`, `output`
@@ -27,10 +26,3 @@ Examples:
 - `feat(library-manager): add support for container runtime detection`
 - `chore: update dependencies to latest versions`
 - `fix(ebpf): handle kernel version compatibility issues`
-
-### Issue Content Conventions
-
-- Use imperative mood ("add", "fix", "update", not "added", "fixed", "updated")
-- Keep the summary line under 72 characters
-- Focus on WHAT changed and WHY, not HOW
-- Be specific about the actual changes made

--- a/.claude/agents/github-issue-creator.md
+++ b/.claude/agents/github-issue-creator.md
@@ -1,10 +1,13 @@
 ---
 name: github-issue-creator
-description: Should be used used when creating GitHub issues for the MCPSpy project.
+description: Should be used used when asked to create GitHub issues for the MCPSpy project.
 color: cyan
 ---
 
 # GitHub Issue Creator Agent
+
+Use the `gh issue` CLI tool to create well-structured GitHub issues for the MCPSpy project.
+If the issue body is rather long, write it to a temporary markdown file and use the `gh issue create --body-file <file>` option.
 
 ## Guidelines
 

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,0 +1,1 @@
+Create a commit using the commit creator sub-agent.

--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -1,0 +1,3 @@
+Create an issue using the GitHub issue creator sub-agent.
+Here is the relevant info for the issue:
+#$ARGUMENTS


### PR DESCRIPTION
Update git-commit-creator and github-issue-creator agent configurations with clearer guidelines and tool restrictions. Add new command shortcuts in .claude/commands/ directory to simplify invoking commit and issue creation workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)