### PR TITLE
feat(ebpf): consolidate stdio read/write correlation in kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ The test suite includes:
 
 - **FS Events Buffer Size**: Limited to 16KB per message. This means MCP messages with **buffer size** greater than 16KB will be missed / ignored.
 - **FS Events Constructed of Multiple Messages**: MCPSpy currently does not support reconstructing MCP messages that are split across multiple `read` or `write` syscalls. This means that if an MCP message is larger than the buffer size used in a single syscall, it may be missed or ignored.
+- **Inode Collision for Stdio Transport**: Inode numbers are only unique within a filesystem. If monitoring processes across multiple filesystems or mount namespaces, inode collisions are theoretically possible but rare in practice for pipe-based stdio communication.
 - **Platform**: Linux only (kernel 5.15+).
 
 ## Contributing

--- a/bpf/helpers.h
+++ b/bpf/helpers.h
@@ -11,7 +11,8 @@
 // Currently the options are:
 // - "node"
 // - "libssl.so*" (OpenSSL shared libraries - covers both 1.x and 3.x)
-// Note: libssl3.so is NSS (Network Security Services), not OpenSSL, so we exclude it
+// Note: libssl3.so is NSS (Network Security Services), not OpenSSL, so we
+// exclude it
 static __always_inline bool is_filename_relevant(const char *filename) {
     // Check if filename is "node"
     if (filename[0] == 'n' && filename[1] == 'o' && filename[2] == 'd' &&
@@ -75,6 +76,17 @@ static __always_inline bool is_directory(struct dentry *dentry) {
     }
 
     return (inode->i_mode & S_IFMT) == S_IFDIR;
+}
+
+// Check if file's inode is a pipe (FIFO).
+// This is used to filter stdio-based MCP communication which uses pipes.
+static __always_inline bool is_pipe(struct file *file) {
+    if (!file) {
+        return false;
+    }
+
+    __u16 i_mode = BPF_CORE_READ(file, f_inode, i_mode);
+    return (i_mode & S_IFMT) == S_IFIFO;
 }
 
 // Get the mount namespace ID of the current task

--- a/cmd/mcpspy/main.go
+++ b/cmd/mcpspy/main.go
@@ -249,12 +249,9 @@ func run(cmd *cobra.Command, args []string) error {
 				}
 
 				// Parse raw eBPF event data into MCP messages
-				messages, err := parser.ParseDataStdio(buf, e.EventType, e.PID, e.Comm())
+				messages, err := parser.ParseDataStdio(buf, e.EventType, e.FromPID, e.FromCommStr(), e.ToPID, e.ToCommStr())
 				if err != nil {
-					// Ignore this error, it's expected for read events
-					if err.Error() != "no write event found for the parsed read event" {
-						logrus.WithError(err).Debugf("Failed to process %s event", e.Type())
-					}
+					logrus.WithError(err).Debugf("Failed to process %s event", e.Type())
 					continue
 				}
 

--- a/pkg/ebpf/loader.go
+++ b/pkg/ebpf/loader.go
@@ -71,7 +71,7 @@ func (l *Loader) Load() error {
 		AttachType: ebpf.AttachTraceFExit,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to attach %s tracepoint: %w", l.objs.ExitVfsRead.String(), err)
+		return fmt.Errorf("failed to attach %s fexit: %w", l.objs.ExitVfsRead.String(), err)
 	}
 	l.links = append(l.links, readEnterLink)
 
@@ -81,7 +81,7 @@ func (l *Loader) Load() error {
 		AttachType: ebpf.AttachTraceFExit,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to attach %s tracepoint: %w", l.objs.ExitVfsWrite.String(), err)
+		return fmt.Errorf("failed to attach %s fexit: %w", l.objs.ExitVfsWrite.String(), err)
 	}
 	l.links = append(l.links, readExitLink)
 
@@ -91,9 +91,19 @@ func (l *Loader) Load() error {
 		AttachType: ebpf.AttachTraceFEntry,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to attach %s tracepoint: %w", l.objs.TraceSecurityFileOpen.String(), err)
+		return fmt.Errorf("failed to attach %s fentry: %w", l.objs.TraceSecurityFileOpen.String(), err)
 	}
 	l.links = append(l.links, securityFileOpenLink)
+
+	// Attaching trace_destroy_inode with Fentry for inode cleanup
+	destroyInodeLink, err := link.AttachTracing(link.TracingOptions{
+		Program:    l.objs.TraceDestroyInode,
+		AttachType: ebpf.AttachTraceFEntry,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to attach %s fentry: %w", l.objs.TraceDestroyInode.String(), err)
+	}
+	l.links = append(l.links, destroyInodeLink)
 
 	// Open the ring buffer reader
 	reader, err := ringbuf.NewReader(l.objs.Events)

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -91,12 +91,26 @@ func (h *EventHeader) Comm() string {
 type FSDataEvent struct {
 	EventHeader
 
+	Inode    uint32    // Inode number for correlation
+	FromPID  uint32    // Sender (writer) PID
+	FromComm [16]uint8 // Sender comm
+	ToPID    uint32    // Receiver (reader) PID
+	ToComm   [16]uint8 // Receiver comm
+
 	Size    uint32           // Actual data size
 	BufSize uint32           // Size of data in buf (may be truncated)
 	Buf     [16 * 1024]uint8 // Data buffer
 }
 
 func (e *FSDataEvent) Type() EventType { return e.EventType }
+
+func (e *FSDataEvent) FromCommStr() string {
+	return encoder.BytesToStr(e.FromComm[:])
+}
+
+func (e *FSDataEvent) ToCommStr() string {
+	return encoder.BytesToStr(e.ToComm[:])
+}
 
 // LibraryEvent represents a new loaded library in memory.
 // used for uprobe hooking for tls inspection

--- a/pkg/http/sessionmanager.go
+++ b/pkg/http/sessionmanager.go
@@ -84,7 +84,9 @@ func (s *SessionManager) ProcessTlsEvent(e *event.TlsPayloadEvent) error {
 			pid:         e.PID,
 			comm:        e.CommBytes,
 			sslContext:  e.SSLContext,
+			request:     &httpRequest{},
 			requestBuf:  &bytes.Buffer{},
+			response:    &httpResponse{},
 			responseBuf: &bytes.Buffer{},
 		}
 		s.sessions[e.SSLContext] = sess

--- a/pkg/http/sessionmanager_test.go
+++ b/pkg/http/sessionmanager_test.go
@@ -1527,58 +1527,58 @@ func TestParseSSEEvents(t *testing.T) {
 		expected []string
 	}{
 		{
-			name: "single data event",
-			input: "data: hello world\n\n",
+			name:     "single data event",
+			input:    "data: hello world\n\n",
 			expected: []string{"data: hello world"},
 		},
 		{
-			name: "multiple data lines in one event",
-			input: "data: line 1\ndata: line 2\n\n",
+			name:     "multiple data lines in one event",
+			input:    "data: line 1\ndata: line 2\n\n",
 			expected: []string{"data: line 1\ndata: line 2"},
 		},
 		{
-			name: "event with id and data",
-			input: "id: 123\ndata: some data\n\n",
+			name:     "event with id and data",
+			input:    "id: 123\ndata: some data\n\n",
 			expected: []string{"id: 123\ndata: some data"},
 		},
 		{
-			name: "multiple events",
-			input: "data: event 1\n\ndata: event 2\n\n",
+			name:     "multiple events",
+			input:    "data: event 1\n\ndata: event 2\n\n",
 			expected: []string{"data: event 1", "data: event 2"},
 		},
 		{
-			name: "event with all fields",
-			input: "event: message\nid: 456\nretry: 1000\ndata: complete event\n\n",
+			name:     "event with all fields",
+			input:    "event: message\nid: 456\nretry: 1000\ndata: complete event\n\n",
 			expected: []string{"event: message\nid: 456\nretry: 1000\ndata: complete event"},
 		},
 		{
-			name: "events with comments (ignored)",
-			input: ": this is a comment\ndata: actual data\n\n",
+			name:     "events with comments (ignored)",
+			input:    ": this is a comment\ndata: actual data\n\n",
 			expected: []string{"data: actual data"},
 		},
 		{
-			name: "CRLF line endings",
-			input: "data: with crlf\r\n\r\n",
+			name:     "CRLF line endings",
+			input:    "data: with crlf\r\n\r\n",
 			expected: []string{"data: with crlf"},
 		},
 		{
-			name: "mixed field types",
-			input: "event: test\ndata: first\nid: 789\ndata: second\n\nevent: another\ndata: third\n\n",
+			name:     "mixed field types",
+			input:    "event: test\ndata: first\nid: 789\ndata: second\n\nevent: another\ndata: third\n\n",
 			expected: []string{"event: test\ndata: first\nid: 789\ndata: second", "event: another\ndata: third"},
 		},
 		{
-			name: "empty input",
-			input: "",
+			name:     "empty input",
+			input:    "",
 			expected: nil,
 		},
 		{
-			name: "only comments",
-			input: ": comment 1\n: comment 2\n\n",
+			name:     "only comments",
+			input:    ": comment 1\n: comment 2\n\n",
 			expected: nil,
 		},
 		{
-			name: "lines without colons (ignored)",
-			input: "invalid line\ndata: valid data\nanother invalid\n\n",
+			name:     "lines without colons (ignored)",
+			input:    "invalid line\ndata: valid data\nanother invalid\n\n",
 			expected: []string{"data: valid data"},
 		},
 	}
@@ -1618,10 +1618,10 @@ func TestParseSSEEvents_WithoutTerminatingNewline(t *testing.T) {
 
 func TestExtractSSEEventData(t *testing.T) {
 	tests := []struct {
-		name             string
-		input            string
-		expectedType     string
-		expectedData     string
+		name         string
+		input        string
+		expectedType string
+		expectedData string
 	}{
 		{
 			name:         "simple data event",


### PR DESCRIPTION
Move write/read event correlation from userspace parser to kernel-space eBPF using inode tracking for stdio (pipe) communication. This eliminates the need for hash-based caching in userspace and provides more accurate correlation.

Key changes:
- Add inode_process_map BPF hash map to track reader/writer PIDs and comms per inode
- Implement is_pipe() helper to filter stdio pipe communication
- Populate from_pid/to_pid and from_comm/to_comm fields in data_event at kernel level
- Add destroy_inode hook to clean up inode cache when pipes are destroyed
- Remove writeCache LRU from parser - no longer needed
- Update ParseDataStdio to use kernel-provided correlation instead of hash matching
- Simplify parser flow: duplicate detection, JSON-RPC parsing, MCP validation, request/response correlation

Additional improvements:
- Add function names to all bpf_printk calls for better debugging
- Fix code formatting inconsistencies in eBPF programs
- Initialize http session request/response buffers properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)