### PR TITLE
feat(ebpf): add compile-time TRACE logging with runtime log level control

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,11 @@ CGO_ENABLED ?= 0
 BUILD_FLAGS := -ldflags "$(LDFLAGS)"
 TEST_FLAGS := -v -timeout=30s
 
+# eBPF build flags
+# Set MCPSPY_TRACE_LOG=1 to enable compile-time TRACE logging
+# Example: make build MCPSPY_TRACE_LOG=1
+MCPSPY_TRACE_LOG ?= 0
+
 # Directories
 BUILD_DIR := build
 GO_BIN_DIR := $(shell go env GOPATH)/bin
@@ -55,7 +60,7 @@ all: generate build ## Building everything (default target)
 .PHONY: generate
 generate: ## Generate eBPF Go bindings
 	@echo "Generating eBPF Go bindings..."
-	cd pkg/ebpf && go generate
+	cd pkg/ebpf && MCPSPY_TRACE_LOG=$(MCPSPY_TRACE_LOG) go generate
 
 # Build the binary
 .PHONY: build

--- a/bpf/log.h
+++ b/bpf/log.h
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// go:build ignore
+
+#ifndef __LOG_H
+#define __LOG_H
+
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+
+// Log levels - matches logrus Level enumeration
+// https://github.com/sirupsen/logrus/blob/master/logrus.go
+#define LOG_LEVEL_PANIC 0
+#define LOG_LEVEL_FATAL 1
+#define LOG_LEVEL_ERROR 2
+#define LOG_LEVEL_WARN 3
+#define LOG_LEVEL_INFO 4
+#define LOG_LEVEL_DEBUG 5
+#define LOG_LEVEL_TRACE 6
+
+volatile __u32 log_level = LOG_LEVEL_INFO;
+
+#define LOG_ERROR(fmt, ...) bpf_printk("ERROR: " fmt, ##__VA_ARGS__)
+#define LOG_WARN(fmt, ...) bpf_printk("WARN: " fmt, ##__VA_ARGS__)
+#define LOG_INFO(fmt, ...) bpf_printk("INFO: " fmt, ##__VA_ARGS__)
+#define LOG_DEBUG(fmt, ...)                                                    \
+    do {                                                                       \
+        if (log_level >= LOG_LEVEL_DEBUG) {                                    \
+            bpf_printk("DEBUG: " fmt, ##__VA_ARGS__);                          \
+        }                                                                      \
+    } while (0)
+
+// LOG_TRACE: Only compiled if MCPSPY_TRACE_LOG is defined
+// When compiled, only executes if log level is trace
+#ifdef MCPSPY_TRACE_LOG
+#define LOG_TRACE(fmt, ...)                                                    \
+    do {                                                                       \
+        if (log_level >= LOG_LEVEL_TRACE) {                                    \
+            bpf_printk("TRACE: " fmt, ##__VA_ARGS__);                          \
+        }                                                                      \
+    } while (0)
+#else
+// When MCPSPY_TRACE_LOG is not defined, LOG_TRACE is a no-op
+#define LOG_TRACE(fmt, ...) ((void)0)
+#endif
+
+#endif // __LOG_H

--- a/cmd/mcpspy/main.go
+++ b/cmd/mcpspy/main.go
@@ -98,7 +98,7 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Create and load eBPF program
-	loader, err := ebpf.New(level >= logrus.DebugLevel)
+	loader, err := ebpf.New()
 	if err != nil {
 		return fmt.Errorf("failed to create eBPF loader: %w", err)
 	}

--- a/pkg/debug/debug.go
+++ b/pkg/debug/debug.go
@@ -18,7 +18,89 @@ func PrintTracePipe(log *logrus.Logger) error {
 	scanner := bufio.NewScanner(p)
 	scanner.Split(bufio.ScanLines)
 	for scanner.Scan() {
-		log.WithField("type", "kernel_event_t").Debug(strings.TrimSpace(scanner.Text()))
+		// Example line:
+		// mcpspy-linux-am-260585  [015] ...11 63008.728893: bpf_trace_printk: DEBUG: exit_vfs_read: <msg>
+		// <comm>-<pid> [<cpu>] <flags> <timestamp>: bpf_trace_printk: <your message>
+		//
+		// We want to parse the log level from the message and log it accordingly.
+		line := strings.TrimSpace(scanner.Text())
+
+		// Find "bpf_trace_printk: " which marks the start of the actual message
+		bpfMarker := "bpf_trace_printk: "
+		bpfIdx := strings.Index(line, bpfMarker)
+		if bpfIdx == -1 {
+			continue
+		}
+
+		// Parse comm-pid from the beginning of the line
+		// Format: <comm>-<pid> [<cpu>] ...
+		commPidEnd := strings.Index(line, " ")
+		var comm, pid string
+		if commPidEnd != -1 {
+			commPid := line[:commPidEnd]
+			// Find the last hyphen to separate comm from pid
+			lastHyphen := strings.LastIndex(commPid, "-")
+			if lastHyphen != -1 {
+				comm = commPid[:lastHyphen]
+				pid = commPid[lastHyphen+1:]
+			}
+		}
+
+		message := line[bpfIdx+len(bpfMarker):]
+
+		// Check for log level prefix in the message
+		var logLevel logrus.Level
+		var cleanMessage string
+
+		switch {
+		case strings.HasPrefix(message, "ERROR: "):
+			logLevel = logrus.ErrorLevel
+			cleanMessage = message[7:]
+		case strings.HasPrefix(message, "WARN: "):
+			logLevel = logrus.WarnLevel
+			cleanMessage = message[6:]
+		case strings.HasPrefix(message, "INFO: "):
+			logLevel = logrus.InfoLevel
+			cleanMessage = message[6:]
+		case strings.HasPrefix(message, "DEBUG: "):
+			logLevel = logrus.DebugLevel
+			cleanMessage = message[7:]
+		case strings.HasPrefix(message, "TRACE: "):
+			logLevel = logrus.TraceLevel
+			cleanMessage = message[7:]
+		default:
+			// No recognized prefix, log as debug
+			logLevel = logrus.DebugLevel
+			cleanMessage = message
+		}
+
+		if !log.IsLevelEnabled(logLevel) {
+			continue
+		}
+
+		// Log at the appropriate level with structured fields
+		entry := log.WithField("ebpf", true)
+		if comm != "" {
+			entry = entry.WithField("comm", comm)
+		}
+		if pid != "" {
+			entry = entry.WithField("pid", pid)
+		}
+
+		switch logLevel {
+		case logrus.ErrorLevel:
+			entry.Error(cleanMessage)
+		case logrus.WarnLevel:
+			entry.Warn(cleanMessage)
+		case logrus.InfoLevel:
+			entry.Info(cleanMessage)
+		case logrus.DebugLevel:
+			entry.Debug(cleanMessage)
+		case logrus.TraceLevel:
+			entry.Trace(cleanMessage)
+		default:
+			entry.Debug(cleanMessage)
+		}
 	}
 
 	return nil

--- a/pkg/ebpf/loader_amd64.go
+++ b/pkg/ebpf/loader_amd64.go
@@ -6,4 +6,4 @@ import _ "embed"
 
 type archObjects = mcpspy_bpfel_x86Objects
 
-var loadArchObjects = loadMcpspy_bpfel_x86Objects
+var loadArchSpec = loadMcpspy_bpfel_x86

--- a/pkg/ebpf/loader_arm64.go
+++ b/pkg/ebpf/loader_arm64.go
@@ -6,4 +6,4 @@ import _ "embed"
 
 type archObjects = mcpspy_bpfel_arm64Objects
 
-var loadArchObjects = loadMcpspy_bpfel_arm64Objects
+var loadArchSpec = loadMcpspy_bpfel_arm64


### PR DESCRIPTION
Implements a structured logging system for eBPF programs with compile-time TRACE support and runtime log level control that matches the userspace Go application's log levels.

Key changes:
- Add bpf/log.h with LOG_ERROR, LOG_WARN, LOG_INFO, LOG_DEBUG, and LOG_TRACE macros
- LOG_TRACE is compile-time controlled via MCPSPY_TRACE_LOG flag
- Runtime log level control via 'log_level' variable in .data section
- Update all bpf_printk calls to use structured logging macros
- Enhance pkg/debug/debug.go to parse and respect eBPF log levels
- Add MCPSPY_TRACE_LOG build flag to Makefile (default: 0)
- Update go:generate directives to conditionally compile with -DMCPSPY_TRACE_LOG

Technical details:
- eBPF log levels match logrus enumeration (0-6)
- Userspace sets eBPF log_level via .data section rewrite before loading
- TRACE logs add visibility to function entry/exit and session lookups
- Changed generic error messages to use appropriate levels (WARN/DEBUG)
- Renamed is_mcp_data() to is_json() for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)