### PR TITLE
feat(ebpf): filter out self-generated events from mcpspy process

### DIFF
--- a/bpf/helpers.h
+++ b/bpf/helpers.h
@@ -109,4 +109,21 @@ static __always_inline __u32 get_mount_ns_id(void) {
     return BPF_CORE_READ(mnt_ns, ns.inum);
 }
 
+// Check if the given PID belongs to the mcpspy process itself
+// and should be ignored
+static __always_inline bool should_ignore_pid(__u32 pid) {
+    __u32 key = 0;
+    __u32 *mcpspy_pid = bpf_map_lookup_elem(&mcpspy_pid_map, &key);
+    if (!mcpspy_pid) {
+        return false;
+    }
+
+    // 0 means not set, so don't filter
+    if (*mcpspy_pid == 0) {
+        return false;
+    }
+
+    return pid == *mcpspy_pid;
+}
+
 #endif // __HELPERS_H

--- a/bpf/types.h
+++ b/bpf/types.h
@@ -61,6 +61,15 @@ struct {
     __type(value, struct inode_process_info);
 } inode_process_map SEC(".maps");
 
+// Map to store the PID of the mcpspy process itself
+// Key is always 0, value is the PID to ignore
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __uint(max_entries, 1);
+    __type(key, __u32);
+    __type(value, __u32);
+} mcpspy_pid_map SEC(".maps");
+
 // Common header for all events
 // Parsed first to get the event type.
 struct event_header {

--- a/cmd/mcpspy/main.go
+++ b/cmd/mcpspy/main.go
@@ -98,7 +98,7 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Create and load eBPF program
-	loader, err := ebpf.New()
+	loader, err := ebpf.New(uint32(os.Getpid()))
 	if err != nil {
 		return fmt.Errorf("failed to create eBPF loader: %w", err)
 	}


### PR DESCRIPTION
Add PID filtering mechanism to prevent mcpspy from monitoring its own eBPF events, reducing noise and overhead. This is implemented by:

- Adding mcpspy_pid_map BPF map to store the mcpspy process PID
- Adding should_ignore_pid() helper function to check if a PID should be filtered
- Applying PID filtering to all eBPF probes:
  - exit_vfs_read/exit_vfs_write (stdio monitoring)
  - enumerate_loaded_modules/trace_security_file_open (library tracking)
  - SSL_read/SSL_write/SSL_read_ex/SSL_write_ex (TLS monitoring)
  - ssl_new_exit/ssl_free_entry/ssl_do_handshake_entry (SSL lifecycle)
- Passing mcpspy PID from Go application to eBPF program during initialization

🤖 Generated with [Claude Code](https://claude.com/claude-code)