### PR TITLE
fix(ebpf): implement smart retry mechanism for transient library loading errors

### DIFF
--- a/bpf/mcpspy.c
+++ b/bpf/mcpspy.c
@@ -306,7 +306,7 @@ int enumerate_loaded_modules(struct bpf_iter__task_vma *ctx) {
     event->header.event_type = EVENT_LIBRARY;
     event->header.pid = pid;
     event->inode = file->f_inode->i_ino;
-    event->mnt_ns_id = get_mount_ns_id();
+    event->mnt_ns_id = get_file_mount_ns_id(file);
     bpf_probe_read_kernel_str(&event->header.comm, sizeof(event->header.comm),
                               task->comm);
     __builtin_memset(event->path, 0, PATH_MAX);
@@ -371,7 +371,7 @@ int BPF_PROG(trace_security_file_open, struct file *file) {
     event->header.event_type = EVENT_LIBRARY;
     event->header.pid = pid;
     event->inode = file->f_inode->i_ino;
-    event->mnt_ns_id = get_mount_ns_id();
+    event->mnt_ns_id = get_file_mount_ns_id(file);
     bpf_get_current_comm(&event->header.comm, sizeof(event->header.comm));
 
     if (!is_path_relevant((const char *)event->path)) {


### PR DESCRIPTION
Improve library manager retry logic to distinguish between transient and permanent failures, reducing unnecessary attach attempts while still handling recoverable errors:

- Add get_file_mount_ns_id() helper to retrieve mount namespace from file descriptor rather than current task context
- Use file's mount namespace in library events for accurate cross-namespace tracking
- Implement retryable error detection based on error patterns (e.g., "no such file or directory")
- Skip retries for permanent failures (e.g., "probe failed") to reduce overhead
- Update tests to verify both retryable and non-retryable error paths

The retry logic distinguishes between errors that can resolve over time (like "no such file or directory", where the file may become available later) versus permanent errors (like missing symbols in a library that won't change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)