### PR TITLE
refactor: introduce event bus architecture for decoupled component communication

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,16 +17,30 @@ MCPSpy is a CLI utility that uses eBPF to monitor MCP (Model Context Protocol) c
 mcpspy/
 ├── cmd/mcpspy/          # CLI entry point
 ├── pkg/
+│   ├── bus/             # Event bus for publish-subscribe communication
 │   ├── ebpf/            # eBPF loading and management
 │   ├── event/           # Event definitions and handling
-|   |── http/            # HTTP transport parsing and analysis
+│   ├── eventlogger/     # Event logging component
+│   ├── http/            # HTTP transport parsing and analysis
 │   ├── mcp/             # MCP protocol parsing and analysis
 │   └── output/          # Output formatting (console, and file output)
+├── internal/
+│   └── testing/         # Testing utilities (mock event bus, etc.)
 ├── bpf/                 # eBPF C programs
 ├── tests/               # Test files
-├── deploy/docker/  # Docker configuration
+├── deploy/docker/       # Docker configuration
 └── .github/workflows/   # CI/CD workflows
 ```
+
+## Architecture
+
+MCPSpy uses an event-driven architecture with a publish-subscribe pattern:
+
+- **Event Bus (`pkg/bus/`)**: Central communication hub that decouples components
+- Components communicate by publishing and subscribing to typed events
+- The eBPF loader publishes raw events from kernel space
+- The HTTP session manager and MCP parser subscribe to relevant events
+- Output handlers subscribe to parsed MCP messages
 
 ## MCP Protocol Context
 
@@ -41,6 +55,7 @@ mcpspy/
 - Use efficient data structures
 - Minimize data copying between kernel and userspace
 - Filter early in eBPF to reduce overhead
+- Event bus uses asynchronous processing to avoid blocking
 
 ## Building
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/alex-ilgayev/mcpspy
 go 1.24
 
 require (
+	github.com/asaskevich/EventBus v0.0.0-20200907212545-49d423059eef
 	github.com/cilium/ebpf v0.12.3
 	github.com/fatih/color v1.16.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/asaskevich/EventBus v0.0.0-20200907212545-49d423059eef h1:2JGTg6JapxP9/R33ZaagQtAM4EkkSYnIAlOG5EI8gkM=
+github.com/asaskevich/EventBus v0.0.0-20200907212545-49d423059eef/go.mod h1:JS7hed4L1fj0hXcyEejnW57/7LCetXggd+vwrRnYeII=
 github.com/cilium/ebpf v0.12.3 h1:8ht6F9MquybnY97at+VDZb3eQQr8ev79RueWeVaEcG4=
 github.com/cilium/ebpf v0.12.3/go.mod h1:TctK1ivibvI3znr66ljgi4hqOT8EYQjz1KWBfb1UVgM=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=

--- a/internal/testing/testing.go
+++ b/internal/testing/testing.go
@@ -1,0 +1,79 @@
+package testing
+
+import (
+	"sync"
+
+	"github.com/alex-ilgayev/mcpspy/pkg/bus"
+	"github.com/alex-ilgayev/mcpspy/pkg/event"
+)
+
+type mockBus struct {
+	mu          sync.RWMutex
+	subscribers map[event.EventType][]bus.EventProcessor
+	events      chan event.Event
+}
+
+func (mb *mockBus) Publish(e event.Event) {
+	mb.mu.RLock()
+	defer mb.mu.RUnlock()
+
+	// Send to events channel for test assertions
+	select {
+	case mb.events <- e:
+	default:
+		// Non-blocking: if the test isn't consuming events, don't block
+	}
+
+	// Call all subscribers for this event type
+	if processors, ok := mb.subscribers[e.Type()]; ok {
+		for _, processor := range processors {
+			processor(e)
+		}
+	}
+}
+
+func (mb *mockBus) Subscribe(eventType event.EventType, fn bus.EventProcessor) error {
+	mb.mu.Lock()
+	defer mb.mu.Unlock()
+
+	mb.subscribers[eventType] = append(mb.subscribers[eventType], fn)
+	return nil
+}
+
+func (mb *mockBus) Unsubscribe(eventType event.EventType, fn bus.EventProcessor) error {
+	mb.mu.Lock()
+	defer mb.mu.Unlock()
+
+	// Remove the processor from subscribers
+	if processors, ok := mb.subscribers[eventType]; ok {
+		for i, processor := range processors {
+			// Compare function pointers (this is a simplified approach)
+			// In production, you might need a more sophisticated comparison
+			_ = processor
+			// For now, just remove all processors of this type
+			mb.subscribers[eventType] = append(processors[:i], processors[i+1:]...)
+			break
+		}
+	}
+	return nil
+}
+
+func (mb *mockBus) Close() {
+	mb.mu.Lock()
+	defer mb.mu.Unlock()
+
+	close(mb.events)
+	mb.subscribers = make(map[event.EventType][]bus.EventProcessor)
+}
+
+// Events returns the channel that receives published events for test assertions
+func (mb *mockBus) Events() <-chan event.Event {
+	return mb.events
+}
+
+func NewMockBus() *mockBus {
+	return &mockBus{
+		subscribers: make(map[event.EventType][]bus.EventProcessor),
+		events:      make(chan event.Event, 100), // Buffered to avoid blocking
+	}
+}

--- a/pkg/bus/bus.go
+++ b/pkg/bus/bus.go
@@ -1,0 +1,57 @@
+package bus
+
+import (
+	"fmt"
+
+	"github.com/alex-ilgayev/mcpspy/pkg/event"
+	evbus "github.com/asaskevich/EventBus"
+)
+
+type EventProcessor func(e event.Event)
+
+// EventBus is a thread-safe, publish/subscribe system.
+// Using github.com/asaskevich/EventBus behind the scenes.
+type EventBus interface {
+	Publish(e event.Event)
+	Subscribe(eventType event.EventType, fn EventProcessor) error
+	Unsubscribe(eventType event.EventType, fn EventProcessor) error
+	Close()
+}
+
+type eventBus struct {
+	bus evbus.Bus
+}
+
+// New creates a new EventBus.
+func New() EventBus {
+	return &eventBus{
+		bus: evbus.New(),
+	}
+}
+
+// Publish sends an event to all registered subscribers for that event type.
+// The processing is done asynchronously in separate goroutines.
+func (b *eventBus) Publish(e event.Event) {
+	topic := fmt.Sprintf("topic:%s", e.Type().String())
+
+	b.bus.Publish(topic, e)
+}
+
+// Subscribe registers an EventProcessor to receive events it's interested in.
+func (b *eventBus) Subscribe(eventType event.EventType, fn EventProcessor) error {
+	topic := fmt.Sprintf("topic:%s", eventType.String())
+
+	return b.bus.SubscribeAsync(topic, fn, false)
+}
+
+// Unsubscribe removes a previously registered EventProcessor for a specific event type.
+func (b *eventBus) Unsubscribe(eventType event.EventType, fn EventProcessor) error {
+	topic := fmt.Sprintf("topic:%s", eventType.String())
+	return b.bus.Unsubscribe(topic, fn)
+}
+
+// Close cleans up the EventBus resources.
+func (b *eventBus) Close() {
+	// No explicit close method in the underlying library,
+	b.bus = evbus.New()
+}

--- a/pkg/bus/bus_test.go
+++ b/pkg/bus/bus_test.go
@@ -1,0 +1,428 @@
+package bus
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/alex-ilgayev/mcpspy/pkg/event"
+)
+
+// testEvent is a simple event implementation for testing
+type testEvent struct {
+	eventType event.EventType
+	payload   string
+}
+
+func (e *testEvent) Type() event.EventType {
+	return e.eventType
+}
+
+func TestEventBus_PublishSubscribe(t *testing.T) {
+	bus := New()
+	defer bus.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	received := make(chan event.Event, 1)
+	processor := func(e event.Event) {
+		received <- e
+		wg.Done()
+	}
+
+	// Subscribe to FSRead events
+	err := bus.Subscribe(event.EventTypeFSRead, processor)
+	if err != nil {
+		t.Fatalf("Subscribe failed: %v", err)
+	}
+
+	// Publish an event
+	testEvt := &testEvent{
+		eventType: event.EventTypeFSRead,
+		payload:   "test payload",
+	}
+	bus.Publish(testEvt)
+
+	// Wait for event to be processed with timeout
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timeout waiting for event to be processed")
+	}
+
+	// Verify the received event
+	select {
+	case evt := <-received:
+		if evt.Type() != event.EventTypeFSRead {
+			t.Errorf("Expected event type %v, got %v", event.EventTypeFSRead, evt.Type())
+		}
+		if testEvt, ok := evt.(*testEvent); ok {
+			if testEvt.payload != "test payload" {
+				t.Errorf("Expected payload 'test payload', got '%s'", testEvt.payload)
+			}
+		}
+	default:
+		t.Error("No event received")
+	}
+}
+
+func TestEventBus_MultipleSubscribers(t *testing.T) {
+	bus := New()
+	defer bus.Close()
+
+	const numSubscribers = 5
+	var wg sync.WaitGroup
+	wg.Add(numSubscribers)
+
+	receivedCount := make(chan int, numSubscribers)
+
+	// Subscribe multiple processors to the same event type
+	for i := 0; i < numSubscribers; i++ {
+		subscriberID := i
+		processor := func(e event.Event) {
+			receivedCount <- subscriberID
+			wg.Done()
+		}
+		err := bus.Subscribe(event.EventTypeFSWrite, processor)
+		if err != nil {
+			t.Fatalf("Subscribe failed for subscriber %d: %v", i, err)
+		}
+	}
+
+	// Publish a single event
+	testEvt := &testEvent{
+		eventType: event.EventTypeFSWrite,
+		payload:   "multi-subscriber test",
+	}
+	bus.Publish(testEvt)
+
+	// Wait for all subscribers to process with timeout
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timeout waiting for all subscribers to process event")
+	}
+
+	// Verify all subscribers received the event
+	close(receivedCount)
+	received := make(map[int]bool)
+	for id := range receivedCount {
+		received[id] = true
+	}
+
+	if len(received) != numSubscribers {
+		t.Errorf("Expected %d subscribers to receive event, got %d", numSubscribers, len(received))
+	}
+}
+
+func TestEventBus_MultipleEventTypes(t *testing.T) {
+	bus := New()
+	defer bus.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	receivedFSRead := make(chan bool, 1)
+	receivedFSWrite := make(chan bool, 1)
+
+	// Subscribe to FSRead events
+	processorRead := func(e event.Event) {
+		if e.Type() == event.EventTypeFSRead {
+			receivedFSRead <- true
+		}
+		wg.Done()
+	}
+	err := bus.Subscribe(event.EventTypeFSRead, processorRead)
+	if err != nil {
+		t.Fatalf("Subscribe to FSRead failed: %v", err)
+	}
+
+	// Subscribe to FSWrite events
+	processorWrite := func(e event.Event) {
+		if e.Type() == event.EventTypeFSWrite {
+			receivedFSWrite <- true
+		}
+		wg.Done()
+	}
+	err = bus.Subscribe(event.EventTypeFSWrite, processorWrite)
+	if err != nil {
+		t.Fatalf("Subscribe to FSWrite failed: %v", err)
+	}
+
+	// Publish both event types
+	bus.Publish(&testEvent{eventType: event.EventTypeFSRead, payload: "read"})
+	bus.Publish(&testEvent{eventType: event.EventTypeFSWrite, payload: "write"})
+
+	// Wait with timeout
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timeout waiting for events to be processed")
+	}
+
+	// Verify both events were received
+	select {
+	case <-receivedFSRead:
+	case <-time.After(100 * time.Millisecond):
+		t.Error("FSRead event not received")
+	}
+
+	select {
+	case <-receivedFSWrite:
+	case <-time.After(100 * time.Millisecond):
+		t.Error("FSWrite event not received")
+	}
+}
+
+func TestEventBus_SubscriberIsolation(t *testing.T) {
+	bus := New()
+	defer bus.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	wrongEventReceived := false
+	var mu sync.Mutex
+
+	// Subscribe only to FSRead events
+	processor := func(e event.Event) {
+		mu.Lock()
+		defer mu.Unlock()
+		if e.Type() != event.EventTypeFSRead {
+			wrongEventReceived = true
+		}
+		wg.Done()
+	}
+	err := bus.Subscribe(event.EventTypeFSRead, processor)
+	if err != nil {
+		t.Fatalf("Subscribe failed: %v", err)
+	}
+
+	// Publish FSWrite event (should not be received)
+	bus.Publish(&testEvent{eventType: event.EventTypeFSWrite, payload: "should not receive"})
+
+	// Wait a bit to ensure it's not received
+	time.Sleep(100 * time.Millisecond)
+
+	// Publish FSRead event (should be received)
+	bus.Publish(&testEvent{eventType: event.EventTypeFSRead, payload: "should receive"})
+
+	// Wait for the correct event
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timeout waiting for event to be processed")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if wrongEventReceived {
+		t.Error("Subscriber received event of wrong type")
+	}
+}
+
+func TestEventBus_Unsubscribe(t *testing.T) {
+	bus := New()
+	defer bus.Close()
+
+	eventCount := 0
+	var mu sync.Mutex
+
+	processor := func(e event.Event) {
+		mu.Lock()
+		eventCount++
+		mu.Unlock()
+	}
+
+	// Subscribe
+	err := bus.Subscribe(event.EventTypeLibrary, processor)
+	if err != nil {
+		t.Fatalf("Subscribe failed: %v", err)
+	}
+
+	// Publish first event
+	bus.Publish(&testEvent{eventType: event.EventTypeLibrary, payload: "first"})
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	firstCount := eventCount
+	mu.Unlock()
+
+	if firstCount != 1 {
+		t.Errorf("Expected 1 event received, got %d", firstCount)
+	}
+
+	// Unsubscribe
+	err = bus.Unsubscribe(event.EventTypeLibrary, processor)
+	if err != nil {
+		t.Fatalf("Unsubscribe failed: %v", err)
+	}
+
+	// Publish second event (should not be received)
+	bus.Publish(&testEvent{eventType: event.EventTypeLibrary, payload: "second"})
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	finalCount := eventCount
+	mu.Unlock()
+
+	if finalCount != 1 {
+		t.Errorf("Expected event count to remain 1 after unsubscribe, got %d", finalCount)
+	}
+}
+
+func TestEventBus_ConcurrentPublish(t *testing.T) {
+	bus := New()
+	defer bus.Close()
+
+	const numGoroutines = 10
+	const eventsPerGoroutine = 10
+
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines * eventsPerGoroutine)
+
+	eventCount := 0
+	var mu sync.Mutex
+
+	processor := func(e event.Event) {
+		mu.Lock()
+		eventCount++
+		mu.Unlock()
+		wg.Done()
+	}
+
+	err := bus.Subscribe(event.EventTypeTlsPayloadSend, processor)
+	if err != nil {
+		t.Fatalf("Subscribe failed: %v", err)
+	}
+
+	// Publish events concurrently from multiple goroutines
+	for i := 0; i < numGoroutines; i++ {
+		go func(id int) {
+			for j := 0; j < eventsPerGoroutine; j++ {
+				bus.Publish(&testEvent{
+					eventType: event.EventTypeTlsPayloadSend,
+					payload:   "concurrent",
+				})
+			}
+		}(i)
+	}
+
+	// Wait for all events to be processed with timeout
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success
+	case <-time.After(5 * time.Second):
+		mu.Lock()
+		count := eventCount
+		mu.Unlock()
+		t.Fatalf("Timeout waiting for concurrent events. Received %d/%d events", count, numGoroutines*eventsPerGoroutine)
+	}
+
+	mu.Lock()
+	finalCount := eventCount
+	mu.Unlock()
+
+	expectedCount := numGoroutines * eventsPerGoroutine
+	if finalCount != expectedCount {
+		t.Errorf("Expected %d events, got %d", expectedCount, finalCount)
+	}
+}
+
+func TestEventBus_Close(t *testing.T) {
+	bus := New()
+
+	processor := func(e event.Event) {
+		// No-op
+	}
+
+	err := bus.Subscribe(event.EventTypeHttpRequest, processor)
+	if err != nil {
+		t.Fatalf("Subscribe failed: %v", err)
+	}
+
+	// Close should not panic
+	bus.Close()
+
+	// Publishing after close should not panic
+	// (behavior is implementation-specific, but should not crash)
+	bus.Publish(&testEvent{eventType: event.EventTypeHttpRequest, payload: "after close"})
+
+	// Give it time to process
+	time.Sleep(100 * time.Millisecond)
+}
+
+func TestEventBus_NoSubscribers(t *testing.T) {
+	bus := New()
+	defer bus.Close()
+
+	// Publishing to an event type with no subscribers should not panic
+	bus.Publish(&testEvent{eventType: event.EventTypeHttpResponse, payload: "no subscribers"})
+
+	// Give it time
+	time.Sleep(100 * time.Millisecond)
+}
+
+func TestEventBus_SubscribeError(t *testing.T) {
+	bus := New()
+	defer bus.Close()
+
+	// Test that Subscribe returns an error (or nil) consistently
+	// This tests the contract of the interface
+	processor := func(e event.Event) {}
+
+	err := bus.Subscribe(event.EventTypeMCPMessage, processor)
+	if err != nil {
+		// If Subscribe can return errors, that's fine
+		t.Logf("Subscribe returned error (acceptable): %v", err)
+	}
+}
+
+func TestEventBus_UnsubscribeError(t *testing.T) {
+	bus := New()
+	defer bus.Close()
+
+	processor := func(e event.Event) {}
+
+	// Unsubscribe without subscribing first
+	err := bus.Unsubscribe(event.EventTypeHttpSSE, processor)
+	if err != nil {
+		// If Unsubscribe can return errors, that's fine
+		t.Logf("Unsubscribe returned error (acceptable): %v", err)
+	}
+}

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -23,6 +23,8 @@ const (
 	EventTypeHttpResponse EventType = 101
 	// Received an SSE event through an existing HTTP connection.
 	EventTypeHttpSSE EventType = 102
+	// Detected a parsed MCP message
+	EventTypeMCPMessage EventType = 103
 )
 
 type HttpVersion uint8
@@ -103,13 +105,14 @@ type FSDataEvent struct {
 }
 
 func (e *FSDataEvent) Type() EventType { return e.EventType }
-
 func (e *FSDataEvent) FromCommStr() string {
 	return encoder.BytesToStr(e.FromComm[:])
 }
-
 func (e *FSDataEvent) ToCommStr() string {
 	return encoder.BytesToStr(e.ToComm[:])
+}
+func (e *FSDataEvent) Buffer() []byte {
+	return e.Buf[:e.BufSize]
 }
 
 // LibraryEvent represents a new loaded library in memory.

--- a/pkg/event/mcp.go
+++ b/pkg/event/mcp.go
@@ -1,0 +1,97 @@
+package event
+
+import "time"
+
+// JSONRPCMessageType represents the type of JSON-RPC message
+type JSONRPCMessageType string
+
+const (
+	JSONRPCMessageTypeRequest      JSONRPCMessageType = "request"
+	JSONRPCMessageTypeResponse     JSONRPCMessageType = "response"
+	JSONRPCMessageTypeNotification JSONRPCMessageType = "notification"
+)
+
+// TransportType represents the type of transport
+type TransportType string
+
+const (
+	TransportTypeStdio TransportType = "stdio"
+	TransportTypeSSE   TransportType = "sse"
+	TransportTypeHTTP  TransportType = "http"
+)
+
+// StdioTransport represents the info relevant for the stdio transport.
+type StdioTransport struct {
+	FromPID  uint32 `json:"from_pid"`
+	FromComm string `json:"from_comm"`
+	ToPID    uint32 `json:"to_pid"`
+	ToComm   string `json:"to_comm"`
+}
+
+type HttpTransport struct {
+	PID       uint32 `json:"pid,omitempty"`
+	Comm      string `json:"comm,omitempty"`
+	Host      string `json:"host,omitempty"`
+	IsRequest bool   `json:"is_request,omitempty"`
+}
+
+// JSONRPCMessage represents a parsed JSON-RPC 2.0 message.
+type JSONRPCMessage struct {
+	MessageType JSONRPCMessageType     `json:"type"`
+	ID          interface{}            `json:"id,omitempty"` // string or number
+	Method      string                 `json:"method,omitempty"`
+	Params      map[string]interface{} `json:"params,omitempty"`
+	Result      interface{}            `json:"result,omitempty"`
+	Error       JSONRPCError           `json:"error,omitempty"`
+}
+
+// JSONRPCError represents a JSON-RPC error
+type JSONRPCError struct {
+	Code    int         `json:"code,omitempty"`
+	Message string      `json:"message,omitempty"`
+	Data    interface{} `json:"data,omitempty"`
+}
+
+// MCPEvent represents a parsed MCP message
+type MCPEvent struct {
+	Timestamp       time.Time     `json:"timestamp"`
+	TransportType   TransportType `json:"transport_type"`
+	*StdioTransport `json:"stdio_transport,omitempty"`
+	*HttpTransport  `json:"http_transport,omitempty"`
+
+	JSONRPCMessage
+
+	Raw string `json:"raw"`
+}
+
+func (e *MCPEvent) Type() EventType { return EventTypeMCPMessage }
+
+// ExtractToolName attempts to extract tool name from a tools/call request
+func (msg *MCPEvent) ExtractToolName() string {
+	if msg.Method != "tools/call" || msg.Params == nil {
+		return ""
+	}
+
+	if name, ok := msg.Params["name"].(string); ok {
+		return name
+	}
+
+	return ""
+}
+
+// ExtractResourceURI attempts to extract resource URI from resource-related requests
+func (msg *MCPEvent) ExtractResourceURI() string {
+	// Check if this is a resource method that has a URI parameter
+	if (msg.Method != "resources/read" &&
+		msg.Method != "resources/subscribe" &&
+		msg.Method != "resources/unsubscribe") ||
+		msg.Params == nil {
+		return ""
+	}
+
+	if uri, ok := msg.Params["uri"].(string); ok {
+		return uri
+	}
+
+	return ""
+}

--- a/pkg/eventlogger/eventlogger.go
+++ b/pkg/eventlogger/eventlogger.go
@@ -1,0 +1,135 @@
+package eventlogger
+
+import (
+	"github.com/alex-ilgayev/mcpspy/pkg/bus"
+	"github.com/alex-ilgayev/mcpspy/pkg/event"
+	"github.com/sirupsen/logrus"
+)
+
+// EventLogger subscribes to all event types and logs them using logrus
+type EventLogger struct {
+	eventBus bus.EventBus
+}
+
+func New(eventBus bus.EventBus) (*EventLogger, error) {
+	el := &EventLogger{
+		eventBus: eventBus,
+	}
+
+	if err := el.eventBus.Subscribe(event.EventTypeFSRead, el.logEvent); err != nil {
+		return nil, err
+	}
+	if err := el.eventBus.Subscribe(event.EventTypeFSWrite, el.logEvent); err != nil {
+		el.Close()
+		return nil, err
+	}
+	if err := el.eventBus.Subscribe(event.EventTypeLibrary, el.logEvent); err != nil {
+		el.Close()
+		return nil, err
+	}
+	if err := el.eventBus.Subscribe(event.EventTypeTlsPayloadSend, el.logEvent); err != nil {
+		el.Close()
+		return nil, err
+	}
+	if err := el.eventBus.Subscribe(event.EventTypeTlsPayloadRecv, el.logEvent); err != nil {
+		el.Close()
+		return nil, err
+	}
+	if err := el.eventBus.Subscribe(event.EventTypeTlsFree, el.logEvent); err != nil {
+		el.Close()
+		return nil, err
+	}
+	if err := el.eventBus.Subscribe(event.EventTypeHttpRequest, el.logEvent); err != nil {
+		el.Close()
+		return nil, err
+	}
+	if err := el.eventBus.Subscribe(event.EventTypeHttpResponse, el.logEvent); err != nil {
+		el.Close()
+		return nil, err
+	}
+	if err := el.eventBus.Subscribe(event.EventTypeHttpSSE, el.logEvent); err != nil {
+		el.Close()
+		return nil, err
+	}
+	if err := el.eventBus.Subscribe(event.EventTypeMCPMessage, el.logEvent); err != nil {
+		el.Close()
+		return nil, err
+	}
+
+	return el, nil
+}
+
+func (el *EventLogger) logEvent(e event.Event) {
+	switch evt := e.(type) {
+	case *event.LibraryEvent:
+		logrus.WithFields(logrus.Fields{
+			"pid":     evt.PID,
+			"comm":    evt.Comm(),
+			"path":    evt.Path(),
+			"inode":   evt.Inode,
+			"mountNS": evt.MntNSID,
+		}).Trace("Library loaded")
+
+	case *event.TlsPayloadEvent:
+		logrus.WithFields(logrus.Fields{
+			"type":     evt.Type(),
+			"pid":      evt.PID,
+			"comm":     evt.Comm(),
+			"size":     evt.Size,
+			"buf_size": evt.BufSize,
+			"version":  evt.HttpVersion,
+		}).Trace("TLS payload event")
+
+	case *event.TlsFreeEvent:
+		logrus.WithFields(logrus.Fields{
+			"pid":     evt.PID,
+			"comm":    evt.Comm(),
+			"ssl_ctx": evt.SSLContext,
+		}).Trace("TLS free event")
+
+	case *event.HttpRequestEvent:
+		logrus.WithFields(logrus.Fields{
+			"method": evt.Method,
+			"host":   evt.Host,
+			"path":   evt.Path,
+		}).Trace("HTTP request event")
+
+	case *event.HttpResponseEvent:
+		logrus.WithFields(logrus.Fields{
+			"method":     evt.Method,
+			"host":       evt.Host,
+			"path":       evt.Path,
+			"code":       evt.Code,
+			"is_chunked": evt.IsChunked,
+		}).Trace("HTTP response event")
+
+	case *event.SSEEvent:
+		logrus.WithFields(logrus.Fields{
+			"method":    evt.Method,
+			"host":      evt.Host,
+			"path":      evt.Path,
+			"sse_event": evt.SSEEventType,
+		}).Trace("HTTP SSE event")
+
+	case *event.MCPEvent:
+		logrus.WithFields(logrus.Fields{
+			"transport":    evt.TransportType,
+			"message_type": evt.MessageType,
+			"method":       evt.Method,
+			"id":           evt.ID,
+		}).Trace("MCP message event")
+	}
+}
+
+func (el *EventLogger) Close() {
+	el.eventBus.Unsubscribe(event.EventTypeFSRead, el.logEvent)
+	el.eventBus.Unsubscribe(event.EventTypeFSWrite, el.logEvent)
+	el.eventBus.Unsubscribe(event.EventTypeLibrary, el.logEvent)
+	el.eventBus.Unsubscribe(event.EventTypeTlsPayloadSend, el.logEvent)
+	el.eventBus.Unsubscribe(event.EventTypeTlsPayloadRecv, el.logEvent)
+	el.eventBus.Unsubscribe(event.EventTypeTlsFree, el.logEvent)
+	el.eventBus.Unsubscribe(event.EventTypeHttpRequest, el.logEvent)
+	el.eventBus.Unsubscribe(event.EventTypeHttpResponse, el.logEvent)
+	el.eventBus.Unsubscribe(event.EventTypeHttpSSE, el.logEvent)
+	el.eventBus.Unsubscribe(event.EventTypeMCPMessage, el.logEvent)
+}

--- a/pkg/output/display.go
+++ b/pkg/output/display.go
@@ -1,13 +1,8 @@
 package output
 
-import (
-	"github.com/alex-ilgayev/mcpspy/pkg/mcp"
-)
-
 // OutputHandler defines the interface for different output formats
 type OutputHandler interface {
 	PrintHeader()
 	PrintStats(stats map[string]int)
 	PrintInfo(format string, args ...interface{})
-	PrintMessages(messages []*mcp.Message)
 }


### PR DESCRIPTION
Replace direct channel-based event passing with a publish-subscribe event bus pattern to decouple components and improve extensibility. This enables components to subscribe to specific event types without tight coupling, making the system more modular and easier to test.

Key changes:
- Add EventBus interface using asaskevich/EventBus for async pub-sub
- Update all components (LibraryManager, SessionManager, Parser, Output) to subscribe to events
- Remove main event loop logic, delegating to component subscriptions
- Add MCPMessage event type for parsed MCP messages
- Create mock event bus for testing
- Add EventLogger component for event monitoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)