### PR TITLE
chore: improve testing flow with log capture and file ownership handling

### DIFF
--- a/bpf/helpers.h
+++ b/bpf/helpers.h
@@ -123,9 +123,8 @@ static __always_inline __u32 get_file_mount_ns_id(struct file *file) {
     // struct vfsmount is embedded in struct mount at field 'mnt'
     // Use CO-RE to calculate the offset and get to the parent structure
     struct mount *mnt = NULL;
-    __builtin_preserve_access_index(({
-        mnt = container_of(vfs_mnt, struct mount, mnt);
-    }));
+    __builtin_preserve_access_index(
+        ({ mnt = container_of(vfs_mnt, struct mount, mnt); }));
 
     if (!mnt) {
         return 0;

--- a/bpf/types.h
+++ b/bpf/types.h
@@ -86,7 +86,7 @@ struct data_event {
     __u8 from_comm[TASK_COMM_LEN]; // Sender comm
     __u32 to_pid;                  // Receiver (reader) PID
     __u8 to_comm[TASK_COMM_LEN];   // Receiver comm
-    __u8 _pad[4];                  // Explicit padding for 8-byte alignment of file_ptr
+    __u8 _pad[4];   // Explicit padding for 8-byte alignment of file_ptr
     __u64 file_ptr; // File pointer (struct file*) for session tracking
     __u32 size;     // Actual data size
     __u32 buf_size; // Size of data in buf (may be truncated)


### PR DESCRIPTION
Enhances the e2e testing infrastructure and user experience:

Testing improvements:
- Add log capture for mcpspy stdout/stderr during e2e tests
- Display captured logs automatically when tests fail for easier debugging
- Add --mcpspy-flags argument to pass additional flags to mcpspy in tests
- Enable flexible test configuration via mcpspy_flags parameter

User experience improvements:
- Add chownToOriginalUser() function to change output file ownership
- Automatically transfer file ownership to the user who invoked sudo
- Prevent permission issues when accessing output files after mcpspy exits
- Add strconv import for UID/GID parsing

These changes improve the development workflow by making test failures easier to diagnose and eliminating the need for sudo to access output files created by mcpspy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)