### PR TITLE
feat(output): enable TUI mode by default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,9 +67,14 @@ make build
 ## Running
 
 ```bash
+# Run with TUI mode (default)
 sudo ./mcpspy
 
+# Run with static console output (for testing/debugging)
+sudo ./mcpspy --tui=false
+
 # It is must be stopped by sending SIGINT (Ctrl+C) or SIGTERM.
+# In TUI mode, you can also press 'q' to quit.
 ```
 
 ## Testing
@@ -102,3 +107,5 @@ Running solely the mcp e2e tests (without mcpspy):
 make test-e2e-mcp-stdio
 make test-e2e-mcp-https
 ```
+
+**Note:** E2E tests automatically run MCPSpy in static mode (`--tui=false`) to capture output for validation. The test configuration is in `tests/e2e_config.yaml`.

--- a/README.md
+++ b/README.md
@@ -165,21 +165,33 @@ For detailed instructions and real-world examples of monitoring AI services in K
 ### Basic Usage
 
 ```bash
-# Start monitoring MCP communication
+# Start monitoring MCP communication (TUI mode is default)
 sudo mcpspy
 
-# Start monitoring with raw message buffers
-sudo mcpspy -b
+# Start monitoring with static console output (disable TUI)
+sudo mcpspy --tui=false
 
 # Start monitoring and save output to JSONL file
 sudo mcpspy -o output.jsonl
 
-# Stop monitoring with Ctrl+C
+# Stop monitoring with Ctrl+C (or 'q' in TUI mode)
 ```
 
 ### Output Format
 
-#### Console Output
+#### TUI Mode (Default)
+
+MCPSpy runs in interactive Terminal UI mode by default. The TUI provides:
+
+- Interactive table view with scrolling
+- Detailed message inspection (press Enter)
+- Filtering by transport, type, and actor
+- Multiple density modes for different screen sizes
+- Real-time statistics
+
+#### Static Console Output
+
+When running with `--tui=false`:
 
 ```
 
@@ -189,6 +201,8 @@ sudo mcpspy -o output.jsonl
 ```
 
 #### JSONL Output
+
+**Stdio Transport - Request:**
 
 ```json
 {
@@ -207,22 +221,105 @@ sudo mcpspy -o output.jsonl
     "name": "get_weather",
     "arguments": { "city": "New York" }
   },
+  "error": {},
   "raw": "{...}"
 }
 ```
 
-For HTTP/HTTPS transport:
+**Stdio Transport - Response:**
+
+```json
+{
+  "timestamp": "2024-01-15T12:34:56.890Z",
+  "transport_type": "stdio",
+  "stdio_transport": {
+    "from_pid": 12346,
+    "from_comm": "python",
+    "to_pid": 12345,
+    "to_comm": "python"
+  },
+  "type": "response",
+  "id": 7,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "Weather in New York: 20°C"
+      }
+    ],
+    "isError": false
+  },
+  "error": {},
+  "request": {
+    "type": "request",
+    "id": 7,
+    "method": "tools/call",
+    "params": {
+      "name": "get_weather",
+      "arguments": { "city": "New York" }
+    },
+    "error": {}
+  },
+  "raw": "{...}"
+}
+```
+
+**HTTP/HTTPS Transport - Request:**
 
 ```json
 {
   "timestamp": "2024-01-15T12:34:56.789Z",
   "transport_type": "http",
+  "http_transport": {
+    "pid": 47837,
+    "comm": "python",
+    "host": "127.0.0.1:12345",
+    "is_request": true
+  },
   "type": "request",
   "id": 7,
   "method": "tools/call",
   "params": {
     "name": "get_weather",
     "arguments": { "city": "New York" }
+  },
+  "error": {},
+  "raw": "{...}"
+}
+```
+
+**HTTP/HTTPS Transport - Response:**
+
+```json
+{
+  "timestamp": "2024-01-15T12:34:56.890Z",
+  "transport_type": "http",
+  "http_transport": {
+    "pid": 47837,
+    "comm": "python",
+    "host": "127.0.0.1:12345"
+  },
+  "type": "response",
+  "id": 7,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "Weather in New York: 20°C"
+      }
+    ],
+    "isError": false
+  },
+  "error": {},
+  "request": {
+    "type": "request",
+    "id": 7,
+    "method": "tools/call",
+    "params": {
+      "name": "get_weather",
+      "arguments": { "city": "New York" }
+    },
+    "error": {}
   },
   "raw": "{...}"
 }

--- a/cmd/mcpspy/main.go
+++ b/cmd/mcpspy/main.go
@@ -48,7 +48,7 @@ communication by tracking stdio operations and analyzing JSON-RPC 2.0 messages.`
 	rootCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose logging (debug level)")
 	rootCmd.Flags().StringVarP(&outputFile, "output", "o", "", "Output file (JSONL format will be written to file)")
 	rootCmd.Flags().StringVarP(&logLevel, "log-level", "l", "info", "Set log level (trace, debug, info, warn, error, fatal, panic)")
-	rootCmd.Flags().BoolVar(&tui, "tui", false, "Enable TUI (Terminal UI) mode")
+	rootCmd.Flags().BoolVar(&tui, "tui", true, "Enable TUI (Terminal UI) mode. Use --tui=false to disable and use static console output")
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)

--- a/pkg/output/CLAUDE.md
+++ b/pkg/output/CLAUDE.md
@@ -6,23 +6,13 @@ The output package provides display handlers for MCP messages. All handlers subs
 
 ## Output Modes
 
-### Console (`console.go`)
-
-**Streaming text output with colors**
-
-Enable: Default mode (when `--tui` is not specified)
-
-Capabilities:
-
-- Real-time streaming of messages to stdout
-- Optional raw JSON buffers with `--buffers` or `-b` flag (static mode only)
-- Statistics table on exit
-
 ### TUI (`tui.go`)
 
 **Interactive terminal UI built with Bubbletea**
 
-Enable: `--tui` flag
+Enable: **Default mode** (enabled by default)
+
+Disable: Use `--tui=false` flag to switch to static console output
 
 Capabilities:
 
@@ -34,6 +24,18 @@ Capabilities:
 - Circular buffer (1000 messages max)
 
 Keys: ↑↓/jk=navigate, Enter=details, p=pause, t=transport, y=type, a=actor, f=follow, d=density, b=banner, q=quit
+
+### Console (`console.go`)
+
+**Streaming text output with colors**
+
+Enable: `--tui=false` flag
+
+Capabilities:
+
+- Real-time streaming of messages to stdout
+- Optional raw JSON buffers with `--buffers` or `-b` flag (static mode only)
+- Statistics table on exit
 
 ### File Output (`jsonl.go`)
 

--- a/tests/e2e_config.yaml
+++ b/tests/e2e_config.yaml
@@ -11,7 +11,8 @@ defaults:
     # Binary path relative to project root (where make is run)
     # Update this path if your platform is different (e.g., build/mcpspy-linux-arm64)
     binary_path: "build/mcpspy-linux-amd64"
-    flags: ["--log-level", "trace"]
+    # Use --tui=false to disable TUI mode for tests (TUI is now the default)
+    flags: ["--tui=false", "--log-level", "trace"]
     startup_wait_seconds: 2.0
     shutdown_timeout_seconds: 5.0
 

--- a/tests/smoke_test.sh
+++ b/tests/smoke_test.sh
@@ -18,7 +18,7 @@ fi
 echo "Starting MCPSpy smoke test..."
 
 # Start MCPSpy in background and capture output
-"$MCPSPY_PATH" > mcpspy.out 2> mcpspy.err &
+"$MCPSPY_PATH" --tui=false > mcpspy.out 2> mcpspy.err &
 MCPSPY_PID=$!
 
 # Wait a moment to check if process is still running


### PR DESCRIPTION
Make TUI mode the default user experience for MCPSpy:
- Change --tui flag default from false to true in cmd/mcpspy/main.go
- Update documentation to reflect TUI as default mode
- Add --tui=false flag to e2e test config for static output capture
- Enhance README.md with separate examples for stdio/HTTP transports
- Update flag description to clarify how to disable TUI

TUI mode provides better user experience with interactive navigation, message inspection, and real-time filtering. Users can still access static console output with --tui=false for testing or automation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)