### PR TITLE
Plan multi-provider API monitoring expansion

### DIFF
--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -32,6 +32,8 @@ const (
 	EventTypeFSAggregatedWrite EventType = 105
 	// Security alert event (injection/jailbreak detected)
 	EventTypeSecurityAlert EventType = 106
+	// Detected a parsed LLM API message (OpenAI, Anthropic, Gemini, etc.)
+	EventTypeLLMMessage EventType = 107
 )
 
 type HttpVersion uint8
@@ -81,6 +83,8 @@ func (e EventType) String() string {
 		return "fs_aggregated_write"
 	case EventTypeSecurityAlert:
 		return "security_alert"
+	case EventTypeLLMMessage:
+		return "llm_message"
 	default:
 		return "unknown"
 	}

--- a/pkg/event/llm.go
+++ b/pkg/event/llm.go
@@ -1,0 +1,42 @@
+package event
+
+import (
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// LLMMessageType represents the type of LLM message
+type LLMMessageType string
+
+const (
+	LLMMessageTypeRequest     LLMMessageType = "request"      // User request to LLM API
+	LLMMessageTypeStreamChunk LLMMessageType = "stream_chunk" // Streaming delta (partial content)
+	LLMMessageTypeResponse    LLMMessageType = "response"     // Complete response (final)
+)
+
+// LLMEvent represents a parsed LLM API message
+type LLMEvent struct {
+	SessionID   uint64         `json:"session_id"`          // Correlates all events in the same HTTP session
+	Timestamp   time.Time      `json:"timestamp"`
+	MessageType LLMMessageType `json:"message_type"`
+	PID         uint32         `json:"pid"`
+	Comm        string         `json:"comm"`
+	Host        string         `json:"host"`
+	Path        string         `json:"path"`
+	Model       string         `json:"model,omitempty"`
+	Content     string         `json:"content,omitempty"` // Request: user prompt, StreamChunk: delta, Response: full content
+	Error       string         `json:"error,omitempty"`
+}
+
+func (e *LLMEvent) Type() EventType { return EventTypeLLMMessage }
+
+func (e *LLMEvent) LogFields() logrus.Fields {
+	return logrus.Fields{
+		"session_id":   e.SessionID,
+		"message_type": e.MessageType,
+		"model":        e.Model,
+		"pid":          e.PID,
+		"comm":         e.Comm,
+	}
+}

--- a/pkg/llm/detector.go
+++ b/pkg/llm/detector.go
@@ -1,0 +1,28 @@
+package llm
+
+import "strings"
+
+// Provider represents an LLM API provider
+type Provider string
+
+const (
+	ProviderUnknown   Provider = ""
+	ProviderAnthropic Provider = "anthropic"
+)
+
+// DetectProvider detects the LLM provider from HTTP request parameters
+func DetectProvider(host, path string) Provider {
+	host = strings.ToLower(host)
+
+	// Remove query string from path
+	if idx := strings.Index(path, "?"); idx != -1 {
+		path = path[:idx]
+	}
+
+	// Anthropic detection
+	if host == "api.anthropic.com" && path == "/v1/messages" {
+		return ProviderAnthropic
+	}
+
+	return ProviderUnknown
+}

--- a/pkg/llm/detector_test.go
+++ b/pkg/llm/detector_test.go
@@ -1,0 +1,89 @@
+package llm
+
+import "testing"
+
+func TestDetectProvider(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		path string
+		want Provider
+	}{
+		{
+			name: "valid anthropic messages endpoint",
+			host: "api.anthropic.com",
+			path: "/v1/messages",
+			want: ProviderAnthropic,
+		},
+		{
+			name: "anthropic with query params",
+			host: "api.anthropic.com",
+			path: "/v1/messages?version=2023-06-01",
+			want: ProviderAnthropic,
+		},
+		{
+			name: "anthropic case insensitive host",
+			host: "API.ANTHROPIC.COM",
+			path: "/v1/messages",
+			want: ProviderAnthropic,
+		},
+		{
+			name: "wrong host",
+			host: "api.openai.com",
+			path: "/v1/messages",
+			want: ProviderUnknown,
+		},
+		{
+			name: "wrong path",
+			host: "api.anthropic.com",
+			path: "/v1/complete",
+			want: ProviderUnknown,
+		},
+		{
+			name: "empty host",
+			host: "",
+			path: "/v1/messages",
+			want: ProviderUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DetectProvider(tt.host, tt.path)
+			if got != tt.want {
+				t.Errorf("DetectProvider() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsLLMRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		path string
+		want bool
+	}{
+		{
+			name: "anthropic is LLM",
+			host: "api.anthropic.com",
+			path: "/v1/messages",
+			want: true,
+		},
+		{
+			name: "unknown is not LLM",
+			host: "example.com",
+			path: "/api",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DetectProvider(tt.host, tt.path) != ProviderUnknown
+			if got != tt.want {
+				t.Errorf("IsLLMRequest() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/llm/parser.go
+++ b/pkg/llm/parser.go
@@ -1,0 +1,132 @@
+package llm
+
+import (
+	"strings"
+
+	"github.com/alex-ilgayev/mcpspy/pkg/bus"
+	"github.com/alex-ilgayev/mcpspy/pkg/event"
+	"github.com/alex-ilgayev/mcpspy/pkg/llm/providers"
+	"github.com/sirupsen/logrus"
+)
+
+// Parser handles parsing of LLM API messages
+type Parser struct {
+	eventBus  bus.EventBus
+	providers map[Provider]ProviderParser
+}
+
+// NewParser creates a new LLM parser
+func NewParser(eventBus bus.EventBus) (*Parser, error) {
+	p := &Parser{
+		eventBus:  eventBus,
+		providers: make(map[Provider]ProviderParser),
+	}
+
+	// Register providers
+	p.providers[ProviderAnthropic] = providers.NewAnthropicParser()
+
+	if err := p.eventBus.Subscribe(event.EventTypeHttpRequest, p.handleRequest); err != nil {
+		return nil, err
+	}
+	if err := p.eventBus.Subscribe(event.EventTypeHttpResponse, p.handleResponse); err != nil {
+		p.Close()
+		return nil, err
+	}
+	if err := p.eventBus.Subscribe(event.EventTypeHttpSSE, p.handleSSE); err != nil {
+		p.Close()
+		return nil, err
+	}
+
+	logrus.Debug("LLM parser initialized")
+	return p, nil
+}
+
+func (p *Parser) handleRequest(e event.Event) {
+	httpEvent, ok := e.(*event.HttpRequestEvent)
+	if !ok {
+		return
+	}
+
+	provider := DetectProvider(httpEvent.Host, httpEvent.Path)
+	if provider == ProviderUnknown {
+		return
+	}
+
+	parser, ok := p.providers[provider]
+	if !ok {
+		return
+	}
+
+	llmEvent, err := parser.ParseRequest(httpEvent)
+	if err != nil {
+		logrus.WithError(err).Warn("Failed to parse LLM request")
+		return
+	}
+
+	p.eventBus.Publish(llmEvent)
+}
+
+func (p *Parser) handleResponse(e event.Event) {
+	httpEvent, ok := e.(*event.HttpResponseEvent)
+	if !ok {
+		return
+	}
+
+	provider := DetectProvider(httpEvent.Host, httpEvent.Path)
+	if provider == ProviderUnknown {
+		return
+	}
+
+	// Skip streaming responses - they're handled by SSE events
+	if contentType, ok := httpEvent.ResponseHeaders["Content-Type"]; ok {
+		if strings.Contains(strings.ToLower(contentType), "text/event-stream") {
+			return
+		}
+	}
+
+	parser, ok := p.providers[provider]
+	if !ok {
+		return
+	}
+
+	llmEvent, err := parser.ParseResponse(httpEvent)
+	if err != nil {
+		logrus.WithError(err).Warn("Failed to parse LLM response")
+		return
+	}
+
+	p.eventBus.Publish(llmEvent)
+}
+
+func (p *Parser) handleSSE(e event.Event) {
+	sseEvent, ok := e.(*event.SSEEvent)
+	if !ok {
+		return
+	}
+
+	provider := DetectProvider(sseEvent.Host, sseEvent.Path)
+	if provider == ProviderUnknown {
+		return
+	}
+
+	parser, ok := p.providers[provider]
+	if !ok {
+		return
+	}
+
+	llmEvent, _, err := parser.ParseStreamEvent(sseEvent)
+	if err != nil {
+		logrus.WithError(err).Warn("Failed to parse LLM SSE")
+		return
+	}
+
+	if llmEvent != nil && llmEvent.Content != "" {
+		p.eventBus.Publish(llmEvent)
+	}
+}
+
+func (p *Parser) Close() {
+	p.eventBus.Unsubscribe(event.EventTypeHttpRequest, p.handleRequest)
+	p.eventBus.Unsubscribe(event.EventTypeHttpResponse, p.handleResponse)
+	p.eventBus.Unsubscribe(event.EventTypeHttpSSE, p.handleSSE)
+}

--- a/pkg/llm/provider.go
+++ b/pkg/llm/provider.go
@@ -1,0 +1,16 @@
+package llm
+
+import "github.com/alex-ilgayev/mcpspy/pkg/event"
+
+// ProviderParser defines the interface for LLM provider-specific parsers
+type ProviderParser interface {
+	// ParseRequest parses an HTTP request and returns an LLM event
+	ParseRequest(req *event.HttpRequestEvent) (*event.LLMEvent, error)
+
+	// ParseResponse parses a non-streaming HTTP response and returns an LLM event
+	ParseResponse(resp *event.HttpResponseEvent) (*event.LLMEvent, error)
+
+	// ParseStreamEvent parses a single SSE event during streaming
+	// Returns: event (may be nil for skip), done flag, error
+	ParseStreamEvent(sse *event.SSEEvent) (*event.LLMEvent, bool, error)
+}

--- a/pkg/llm/providers/anthropic.go
+++ b/pkg/llm/providers/anthropic.go
@@ -1,0 +1,258 @@
+package providers
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/alex-ilgayev/mcpspy/pkg/event"
+)
+
+// AnthropicStreamEventType represents SSE event types in Anthropic's streaming API.
+// Events are sent in order: message_start → content_block_start → content_block_delta(s) →
+// content_block_stop → message_delta → message_stop
+type AnthropicStreamEventType string
+
+const (
+	// AnthropicStreamEventTypeMessageStart signals the start of a new message.
+	// Contains the message metadata including model, id, and initial usage stats.
+	// This is always the first event in a stream.
+	//
+	// Example: {"type":"message_start","message":{"model":"claude-haiku-4-5-20251001","id":"msg_01HiWiRka7cogGJfB43zxyci","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":3,"cache_creation_input_tokens":0,"cache_read_input_tokens":20012,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}}
+	AnthropicStreamEventTypeMessageStart AnthropicStreamEventType = "message_start"
+
+	// AnthropicStreamEventTypeContentBlockStart signals the start of a content block.
+	// Contains the block index and initial content_block structure (type: "text", empty text).
+	// Sent before any deltas for that block.
+	//
+	// Example: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+	AnthropicStreamEventTypeContentBlockStart AnthropicStreamEventType = "content_block_start"
+
+	// AnthropicStreamEventTypeContentBlockDelta contains incremental text content.
+	// The delta field contains {"type": "text_delta", "text": "..."} with the actual tokens.
+	// Multiple deltas are sent per content block as tokens are generated.
+	//
+	// Example: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hey"}}
+	AnthropicStreamEventTypeContentBlockDelta AnthropicStreamEventType = "content_block_delta"
+
+	// AnthropicStreamEventTypeContentBlockStop signals the end of a content block.
+	// Contains only the block index. Sent after all deltas for that block.
+	//
+	// Example: {"type":"content_block_stop","index":0}
+	AnthropicStreamEventTypeContentBlockStop AnthropicStreamEventType = "content_block_stop"
+
+	// AnthropicStreamEventTypeMessageDelta contains final message metadata.
+	// Includes stop_reason ("end_turn", "max_tokens", etc.) and final usage statistics.
+	// Sent after all content blocks are complete.
+	//
+	// Example: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":3,"cache_creation_input_tokens":0,"cache_read_input_tokens":20012,"output_tokens":80},"context_management":{"applied_edits":[]}}
+	AnthropicStreamEventTypeMessageDelta AnthropicStreamEventType = "message_delta"
+
+	// AnthropicStreamEventTypeMessageStop signals the end of the message stream.
+	// Contains no additional data. This is always the last event in a successful stream.
+	//
+	// Example: {"type":"message_stop"}
+	AnthropicStreamEventTypeMessageStop AnthropicStreamEventType = "message_stop"
+
+	// AnthropicStreamEventTypePing is a keep-alive event sent periodically.
+	// Contains no data. Used to prevent connection timeouts during long generations.
+	//
+	// Example: {"type": "ping"}
+	AnthropicStreamEventTypePing AnthropicStreamEventType = "ping"
+
+	// AnthropicStreamEventTypeError signals an error during streaming.
+	// Contains error details in the error field. Terminates the stream.
+	//
+	// Example: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}
+	AnthropicStreamEventTypeError AnthropicStreamEventType = "error"
+)
+
+// AnthropicParser parses Anthropic Claude API requests and responses
+type AnthropicParser struct{}
+
+func NewAnthropicParser() *AnthropicParser {
+	return &AnthropicParser{}
+}
+
+// Request structure (minimal)
+type anthropicRequest struct {
+	Model    string             `json:"model"`
+	Messages []anthropicMessage `json:"messages"`
+}
+
+type anthropicMessage struct {
+	Role    string      `json:"role"`
+	Content interface{} `json:"content"`
+}
+
+// Response structure (minimal)
+// Note: Error responses have a different structure with "type": "error" at root level
+type anthropicResponse struct {
+	Type    string                  `json:"type,omitempty"` // "message" for success, "error" for errors
+	Model   string                  `json:"model,omitempty"`
+	Content []anthropicContentBlock `json:"content,omitempty"`
+	Error   *anthropicError         `json:"error,omitempty"`
+}
+
+type anthropicContentBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text,omitempty"`
+}
+
+type anthropicError struct {
+	Message string `json:"message"`
+}
+
+// Streaming event structure (minimal)
+type anthropicStreamEvent struct {
+	Type    string             `json:"type"`
+	Message *anthropicResponse `json:"message,omitempty"`
+	Delta   *anthropicDelta    `json:"delta,omitempty"`
+	Error   *anthropicError    `json:"error,omitempty"`
+}
+
+// anthropicDelta represents the delta in content_block_delta events.
+// Note: message_delta events have a different delta structure (stop_reason, stop_sequence)
+// which we ignore, so we don't need to parse those fields.
+type anthropicDelta struct {
+	Type string `json:"type"` // "text_delta" for text content
+	Text string `json:"text,omitempty"`
+}
+
+// ParseRequest parses an Anthropic API request
+func (p *AnthropicParser) ParseRequest(req *event.HttpRequestEvent) (*event.LLMEvent, error) {
+	var anthropicReq anthropicRequest
+	if err := json.Unmarshal(req.RequestPayload, &anthropicReq); err != nil {
+		return nil, err
+	}
+
+	return &event.LLMEvent{
+		SessionID:   req.SSLContext,
+		Timestamp:   time.Now(),
+		MessageType: event.LLMMessageTypeRequest,
+		PID:         req.PID,
+		Comm:        req.Comm(),
+		Host:        req.Host,
+		Path:        req.Path,
+		Model:       anthropicReq.Model,
+		Content:     extractUserPrompt(anthropicReq.Messages),
+	}, nil
+}
+
+// ParseResponse parses an Anthropic API response (non-streaming)
+func (p *AnthropicParser) ParseResponse(resp *event.HttpResponseEvent) (*event.LLMEvent, error) {
+	var anthropicResp anthropicResponse
+	if err := json.Unmarshal(resp.ResponsePayload, &anthropicResp); err != nil {
+		return nil, err
+	}
+
+	ev := &event.LLMEvent{
+		SessionID:   resp.SSLContext,
+		Timestamp:   time.Now(),
+		MessageType: event.LLMMessageTypeResponse,
+		PID:         resp.PID,
+		Comm:        resp.Comm(),
+		Host:        resp.Host,
+		Path:        resp.Path,
+		Model:       anthropicResp.Model,
+	}
+
+	// Check for error response (type: "error" at root level)
+	if anthropicResp.Type == "error" && anthropicResp.Error != nil {
+		ev.Error = anthropicResp.Error.Message
+		return ev, nil
+	}
+
+	ev.Content = extractResponseText(anthropicResp.Content)
+	return ev, nil
+}
+
+// ParseStreamEvent parses an Anthropic streaming SSE event
+// Returns: event (may be nil for skip), done flag, error
+func (p *AnthropicParser) ParseStreamEvent(sse *event.SSEEvent) (*event.LLMEvent, bool, error) {
+	data := strings.TrimSpace(string(sse.Data))
+	if data == "" {
+		return nil, false, nil
+	}
+
+	var streamEvent anthropicStreamEvent
+	if err := json.Unmarshal([]byte(data), &streamEvent); err != nil {
+		return nil, false, err
+	}
+
+	// Check for stream completion
+	done := AnthropicStreamEventType(streamEvent.Type) == AnthropicStreamEventTypeMessageStop
+
+	// Build event by extracting available fields
+	ev := &event.LLMEvent{
+		SessionID:   sse.SSLContext,
+		Timestamp:   time.Now(),
+		MessageType: event.LLMMessageTypeStreamChunk,
+		PID:         sse.PID,
+		Comm:        sse.Comm(),
+		Host:        sse.Host,
+		Path:        sse.Path,
+	}
+
+	// Extract model from message_start
+	if streamEvent.Message != nil && streamEvent.Message.Model != "" {
+		ev.Model = streamEvent.Message.Model
+	}
+
+	// Extract text content from content_block_delta
+	if streamEvent.Delta != nil && streamEvent.Delta.Type == "text_delta" && streamEvent.Delta.Text != "" {
+		ev.Content = streamEvent.Delta.Text
+	}
+
+	// Extract error (terminates stream)
+	if streamEvent.Error != nil && streamEvent.Error.Message != "" {
+		ev.Error = streamEvent.Error.Message
+		return ev, true, nil
+	}
+
+	return ev, done, nil
+}
+
+func extractUserPrompt(messages []anthropicMessage) string {
+	// Get the last user message
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].Role == "user" {
+			return extractMessageContent(messages[i].Content)
+		}
+	}
+	return ""
+}
+
+func extractMessageContent(content interface{}) string {
+	if content == nil {
+		return ""
+	}
+	if s, ok := content.(string); ok {
+		return s
+	}
+	// Array of content blocks
+	if blocks, ok := content.([]interface{}); ok {
+		var texts []string
+		for _, block := range blocks {
+			if m, ok := block.(map[string]interface{}); ok {
+				if m["type"] == "text" {
+					if text, ok := m["text"].(string); ok {
+						texts = append(texts, text)
+					}
+				}
+			}
+		}
+		return strings.Join(texts, "\n")
+	}
+	return ""
+}
+
+func extractResponseText(blocks []anthropicContentBlock) string {
+	var texts []string
+	for _, block := range blocks {
+		if block.Type == "text" && block.Text != "" {
+			texts = append(texts, block.Text)
+		}
+	}
+	return strings.Join(texts, "\n")
+}

--- a/pkg/llm/providers/anthropic_test.go
+++ b/pkg/llm/providers/anthropic_test.go
@@ -1,0 +1,528 @@
+package providers
+
+import (
+	"testing"
+
+	"github.com/alex-ilgayev/mcpspy/pkg/event"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Helper to create EventHeader with comm string
+func makeEventHeader(pid uint32, comm string) event.EventHeader {
+	header := event.EventHeader{
+		PID: pid,
+	}
+	copy(header.CommBytes[:], comm)
+	return header
+}
+
+func TestAnthropicParser_ParseRequest(t *testing.T) {
+	parser := NewAnthropicParser()
+
+	tests := []struct {
+		name            string
+		payload         string
+		expectedModel   string
+		expectedContent string
+		wantErr         bool
+	}{
+		{
+			name: "simple string content",
+			payload: `{
+				"model": "claude-sonnet-4-20250514",
+				"messages": [{"role": "user", "content": "Hello, world!"}]
+			}`,
+			expectedModel:   "claude-sonnet-4-20250514",
+			expectedContent: "Hello, world!",
+		},
+		{
+			name: "array content blocks",
+			payload: `{
+				"model": "claude-haiku-4-5-20251001",
+				"messages": [{
+					"role": "user",
+					"content": [
+						{"type": "text", "text": "First paragraph."},
+						{"type": "text", "text": "Second paragraph."}
+					]
+				}]
+			}`,
+			expectedModel:   "claude-haiku-4-5-20251001",
+			expectedContent: "First paragraph.\nSecond paragraph.",
+		},
+		{
+			name: "multiple messages extracts last user message",
+			payload: `{
+				"model": "claude-opus-4-20250514",
+				"messages": [
+					{"role": "user", "content": "First question"},
+					{"role": "assistant", "content": "First answer"},
+					{"role": "user", "content": "Follow-up question"}
+				]
+			}`,
+			expectedModel:   "claude-opus-4-20250514",
+			expectedContent: "Follow-up question",
+		},
+		{
+			name: "system and user messages",
+			payload: `{
+				"model": "claude-sonnet-4-20250514",
+				"messages": [
+					{"role": "system", "content": "You are helpful"},
+					{"role": "user", "content": "What is 2+2?"}
+				]
+			}`,
+			expectedModel:   "claude-sonnet-4-20250514",
+			expectedContent: "What is 2+2?",
+		},
+		{
+			name: "mixed content types in array",
+			payload: `{
+				"model": "claude-sonnet-4-20250514",
+				"messages": [{
+					"role": "user",
+					"content": [
+						{"type": "image", "source": {"type": "base64", "data": "..."}},
+						{"type": "text", "text": "What is in this image?"}
+					]
+				}]
+			}`,
+			expectedModel:   "claude-sonnet-4-20250514",
+			expectedContent: "What is in this image?",
+		},
+		{
+			name:    "invalid JSON",
+			payload: `{invalid json`,
+			wantErr: true,
+		},
+		{
+			name: "empty messages array",
+			payload: `{
+				"model": "claude-sonnet-4-20250514",
+				"messages": []
+			}`,
+			expectedModel:   "claude-sonnet-4-20250514",
+			expectedContent: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &event.HttpRequestEvent{
+				EventHeader:    makeEventHeader(1234, "python"),
+				SSLContext:     99999,
+				Host:           "api.anthropic.com",
+				Path:           "/v1/messages",
+				RequestPayload: []byte(tt.payload),
+			}
+
+			result, err := parser.ParseRequest(req)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, event.LLMMessageTypeRequest, result.MessageType)
+			assert.Equal(t, tt.expectedModel, result.Model)
+			assert.Equal(t, tt.expectedContent, result.Content)
+			assert.Equal(t, uint32(1234), result.PID)
+			assert.Equal(t, "python", result.Comm)
+			assert.Equal(t, "api.anthropic.com", result.Host)
+			assert.Equal(t, "/v1/messages", result.Path)
+			assert.Equal(t, uint64(99999), result.SessionID)
+		})
+	}
+}
+
+func TestAnthropicParser_ParseResponse(t *testing.T) {
+	parser := NewAnthropicParser()
+
+	tests := []struct {
+		name            string
+		payload         string
+		expectedModel   string
+		expectedContent string
+		expectedError   string
+		wantErr         bool
+	}{
+		{
+			name: "successful response with single text block",
+			payload: `{
+				"type": "message",
+				"model": "claude-sonnet-4-20250514",
+				"content": [{"type": "text", "text": "Hello! How can I help you?"}]
+			}`,
+			expectedModel:   "claude-sonnet-4-20250514",
+			expectedContent: "Hello! How can I help you?",
+		},
+		{
+			name: "successful response with multiple text blocks",
+			payload: `{
+				"type": "message",
+				"model": "claude-sonnet-4-20250514",
+				"content": [
+					{"type": "text", "text": "First part."},
+					{"type": "text", "text": "Second part."}
+				]
+			}`,
+			expectedModel:   "claude-sonnet-4-20250514",
+			expectedContent: "First part.\nSecond part.",
+		},
+		{
+			name: "error response",
+			payload: `{
+				"type": "error",
+				"error": {"type": "invalid_request_error", "message": "Invalid API key"}
+			}`,
+			expectedError: "Invalid API key",
+		},
+		{
+			name: "overloaded error",
+			payload: `{
+				"type": "error",
+				"error": {"type": "overloaded_error", "message": "Overloaded"}
+			}`,
+			expectedError: "Overloaded",
+		},
+		{
+			name: "response with tool use block",
+			payload: `{
+				"type": "message",
+				"model": "claude-sonnet-4-20250514",
+				"content": [
+					{"type": "text", "text": "Let me search for that."},
+					{"type": "tool_use", "id": "toolu_123", "name": "search", "input": {"query": "weather"}}
+				]
+			}`,
+			expectedModel:   "claude-sonnet-4-20250514",
+			expectedContent: "Let me search for that.",
+		},
+		{
+			name:    "invalid JSON",
+			payload: `not json`,
+			wantErr: true,
+		},
+		{
+			name: "empty content array",
+			payload: `{
+				"type": "message",
+				"model": "claude-sonnet-4-20250514",
+				"content": []
+			}`,
+			expectedModel:   "claude-sonnet-4-20250514",
+			expectedContent: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &event.HttpResponseEvent{
+				EventHeader: makeEventHeader(5678, "curl"),
+				HttpRequestEvent: event.HttpRequestEvent{
+					Host: "api.anthropic.com",
+					Path: "/v1/messages",
+				},
+				SSLContext:      88888,
+				ResponsePayload: []byte(tt.payload),
+			}
+
+			result, err := parser.ParseResponse(resp)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, event.LLMMessageTypeResponse, result.MessageType)
+			assert.Equal(t, tt.expectedModel, result.Model)
+			assert.Equal(t, tt.expectedContent, result.Content)
+			assert.Equal(t, tt.expectedError, result.Error)
+			assert.Equal(t, uint32(5678), result.PID)
+			assert.Equal(t, "curl", result.Comm)
+			assert.Equal(t, uint64(88888), result.SessionID)
+		})
+	}
+}
+
+func TestAnthropicParser_ParseStreamEvent(t *testing.T) {
+	parser := NewAnthropicParser()
+
+	tests := []struct {
+		name            string
+		data            string
+		expectedModel   string
+		expectedContent string
+		expectedError   string
+		expectedDone    bool
+		wantErr         bool
+	}{
+		{
+			name:          "message_start extracts model",
+			data:          `{"type":"message_start","message":{"model":"claude-haiku-4-5-20251001","id":"msg_123","type":"message","role":"assistant","content":[]}}`,
+			expectedModel: "claude-haiku-4-5-20251001",
+			expectedDone:  false,
+		},
+		{
+			name:         "content_block_start",
+			data:         `{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+			expectedDone: false,
+		},
+		{
+			name:            "content_block_delta with text",
+			data:            `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}`,
+			expectedContent: "Hello",
+			expectedDone:    false,
+		},
+		{
+			name:            "content_block_delta with longer text",
+			data:            `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" world! How are you today?"}}`,
+			expectedContent: " world! How are you today?",
+			expectedDone:    false,
+		},
+		{
+			name:         "content_block_stop",
+			data:         `{"type":"content_block_stop","index":0}`,
+			expectedDone: false,
+		},
+		{
+			name:         "message_delta",
+			data:         `{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":10}}`,
+			expectedDone: false,
+		},
+		{
+			name:         "message_stop signals done",
+			data:         `{"type":"message_stop"}`,
+			expectedDone: true,
+		},
+		{
+			name:         "ping event",
+			data:         `{"type":"ping"}`,
+			expectedDone: false,
+		},
+		{
+			name:          "error event",
+			data:          `{"type":"error","error":{"type":"overloaded_error","message":"Server overloaded"}}`,
+			expectedError: "Server overloaded",
+			expectedDone:  true,
+		},
+		{
+			name:         "empty data",
+			data:         "",
+			expectedDone: false,
+		},
+		{
+			name:         "whitespace only data",
+			data:         "   \n\t  ",
+			expectedDone: false,
+		},
+		{
+			name:    "invalid JSON",
+			data:    `{broken`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sse := &event.SSEEvent{
+				EventHeader: makeEventHeader(9999, "node"),
+				HttpRequestEvent: event.HttpRequestEvent{
+					Host: "api.anthropic.com",
+					Path: "/v1/messages",
+				},
+				SSLContext: 12345,
+				Data:       []byte(tt.data),
+			}
+
+			result, done, err := parser.ParseStreamEvent(sse)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedDone, done)
+
+			// For empty/whitespace data, result may be nil
+			if tt.data == "" || tt.data == "   \n\t  " {
+				assert.Nil(t, result)
+				return
+			}
+
+			require.NotNil(t, result)
+			assert.Equal(t, event.LLMMessageTypeStreamChunk, result.MessageType)
+			assert.Equal(t, tt.expectedModel, result.Model)
+			assert.Equal(t, tt.expectedContent, result.Content)
+			assert.Equal(t, tt.expectedError, result.Error)
+			assert.Equal(t, uint32(9999), result.PID)
+			assert.Equal(t, "node", result.Comm)
+			assert.Equal(t, uint64(12345), result.SessionID)
+		})
+	}
+}
+
+func TestExtractUserPrompt(t *testing.T) {
+	tests := []struct {
+		name     string
+		messages []anthropicMessage
+		expected string
+	}{
+		{
+			name:     "empty messages",
+			messages: []anthropicMessage{},
+			expected: "",
+		},
+		{
+			name: "single user message",
+			messages: []anthropicMessage{
+				{Role: "user", Content: "Hello"},
+			},
+			expected: "Hello",
+		},
+		{
+			name: "user and assistant messages",
+			messages: []anthropicMessage{
+				{Role: "user", Content: "Question 1"},
+				{Role: "assistant", Content: "Answer 1"},
+				{Role: "user", Content: "Question 2"},
+			},
+			expected: "Question 2",
+		},
+		{
+			name: "only assistant message",
+			messages: []anthropicMessage{
+				{Role: "assistant", Content: "I can help"},
+			},
+			expected: "",
+		},
+		{
+			name: "nil content",
+			messages: []anthropicMessage{
+				{Role: "user", Content: nil},
+			},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractUserPrompt(tt.messages)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestExtractMessageContent(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  interface{}
+		expected string
+	}{
+		{
+			name:     "nil content",
+			content:  nil,
+			expected: "",
+		},
+		{
+			name:     "string content",
+			content:  "Simple text",
+			expected: "Simple text",
+		},
+		{
+			name: "single text block",
+			content: []interface{}{
+				map[string]interface{}{"type": "text", "text": "Block text"},
+			},
+			expected: "Block text",
+		},
+		{
+			name: "multiple text blocks",
+			content: []interface{}{
+				map[string]interface{}{"type": "text", "text": "First"},
+				map[string]interface{}{"type": "text", "text": "Second"},
+			},
+			expected: "First\nSecond",
+		},
+		{
+			name: "mixed block types",
+			content: []interface{}{
+				map[string]interface{}{"type": "image", "source": "data"},
+				map[string]interface{}{"type": "text", "text": "Description"},
+			},
+			expected: "Description",
+		},
+		{
+			name:     "unsupported type",
+			content:  12345,
+			expected: "",
+		},
+		{
+			name:     "empty array",
+			content:  []interface{}{},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractMessageContent(tt.content)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestExtractResponseText(t *testing.T) {
+	tests := []struct {
+		name     string
+		blocks   []anthropicContentBlock
+		expected string
+	}{
+		{
+			name:     "empty blocks",
+			blocks:   []anthropicContentBlock{},
+			expected: "",
+		},
+		{
+			name: "single text block",
+			blocks: []anthropicContentBlock{
+				{Type: "text", Text: "Hello"},
+			},
+			expected: "Hello",
+		},
+		{
+			name: "multiple text blocks",
+			blocks: []anthropicContentBlock{
+				{Type: "text", Text: "First"},
+				{Type: "text", Text: "Second"},
+			},
+			expected: "First\nSecond",
+		},
+		{
+			name: "text and tool_use blocks",
+			blocks: []anthropicContentBlock{
+				{Type: "text", Text: "Let me help"},
+				{Type: "tool_use", Text: ""},
+			},
+			expected: "Let me help",
+		},
+		{
+			name: "empty text in block",
+			blocks: []anthropicContentBlock{
+				{Type: "text", Text: ""},
+			},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractResponseText(tt.blocks)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/output/jsonl.go
+++ b/pkg/output/jsonl.go
@@ -13,6 +13,7 @@ import (
 // JSONLDisplay handles JSONL output formatting
 // Subscribes to the following events:
 // - EventTypeMCPMessage
+// - EventTypeLLMMessage
 type JSONLDisplay struct {
 	writer   io.Writer
 	eventBus bus.EventBus
@@ -35,6 +36,11 @@ func NewJSONLDisplay(writer io.Writer, eventBus bus.EventBus) (*JSONLDisplay, er
 		return nil, err
 	}
 
+	// Subscribe to LLM events
+	if err := eventBus.Subscribe(event.EventTypeLLMMessage, j.printLLMMessage); err != nil {
+		return nil, err
+	}
+
 	return j, nil
 }
 
@@ -53,7 +59,7 @@ func (j *JSONLDisplay) PrintInfo(format string, args ...interface{}) {
 	// No info messages for JSONL format
 }
 
-// printMessage outputs a single message in JSON format
+// printMessage outputs a single MCP message in JSON format
 func (j *JSONLDisplay) printMessage(e event.Event) {
 	msg, ok := e.(*event.MCPEvent)
 	if !ok {
@@ -79,6 +85,24 @@ func (j *JSONLDisplay) printSecurityAlert(e event.Event) {
 	data, err := json.Marshal(alert)
 	if err != nil {
 		logrus.WithError(err).Error("failed to marshal security alert")
+		return
+	}
+
+	fmt.Fprintf(j.writer, "%s\n", string(data))
+}
+
+// printLLMMessage outputs a single LLM message in JSON format
+func (j *JSONLDisplay) printLLMMessage(e event.Event) {
+	msg, ok := e.(*event.LLMEvent)
+	if !ok {
+		return
+	}
+
+	// Skip individual stream chunks to reduce noise (optional - can be configurable)
+	// For now, we include all messages including chunks for comprehensive logging
+	data, err := json.Marshal(msg)
+	if err != nil {
+		logrus.WithError(err).Error("failed to marshal LLM message")
 		return
 	}
 


### PR DESCRIPTION
Add comprehensive LLM API monitoring capability to track completion API calls for major LLM providers. This is an opt-in feature enabled via the --llm flag that monitors HTTP traffic to detect and parse LLM API requests and responses with streaming support.

Core Components:
- pkg/llm/parser.go: Main LLM parser with streaming chunk aggregation
- pkg/llm/detector.go: Provider detection based on URL patterns
- pkg/llm/providers/: Provider-specific parsers for OpenAI, Anthropic, Gemini, and Ollama APIs
- pkg/event/llm.go: LLM event structures (request/response/error)

CLI Integration:
- Added --llm flag to enable LLM monitoring (disabled by default)
- Added --llm-providers flag to filter specific providers
- Extended event bus to handle EventTypeLLMMessage events

Output Support:
- Console output with color-coded LLM events (cyan for requests, green for responses)
- JSONL output format for LLM events
- Displays model, provider, token usage, and request/response content

Testing Infrastructure:
- Mock servers for OpenAI and Anthropic APIs with streaming support
- Test clients for validation
- E2E test scenarios in e2e_config.yaml
- New Makefile targets: test-e2e-llm, test-llm-openai, test-llm-anthropic

Supported Providers:
- OpenAI (api.openai.com)
- Anthropic Claude (api.anthropic.com)
- Google Gemini (generativelanguage.googleapis.com)
- Ollama (localhost:11434)

All providers support both streaming and non-streaming responses with proper SSE (Server-Sent Events) parsing for streaming completions.