### PR TITLE
Add Unix socket support for local MCP

### DIFF
--- a/pkg/ebpf/loader.go
+++ b/pkg/ebpf/loader.go
@@ -143,6 +143,16 @@ func (l *Loader) Load() error {
 	}
 	l.links = append(l.links, destroyInodeLink)
 
+	// Attaching trace_sock_release with Fentry for Unix socket cleanup
+	sockReleaseLink, err := link.AttachTracing(link.TracingOptions{
+		Program:    l.objs.TraceSockRelease,
+		AttachType: ebpf.AttachTraceFEntry,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to attach %s fentry: %w", l.objs.TraceSockRelease.String(), err)
+	}
+	l.links = append(l.links, sockReleaseLink)
+
 	// Open the ring buffer reader
 	reader, err := ringbuf.NewReader(l.objs.Events)
 	if err != nil {

--- a/tests/e2e_config.yaml
+++ b/tests/e2e_config.yaml
@@ -39,7 +39,12 @@ scenarios:
     # No pre_commands needed - client spawns server automatically
 
     traffic:
-      command: ["bash", "-c", "tests/venv/bin/python tests/mcp_client.py --server 'tests/venv/bin/python tests/mcp_server.py'"]
+      command:
+        [
+          "bash",
+          "-c",
+          "tests/venv/bin/python tests/mcp_client.py --server 'tests/venv/bin/python tests/mcp_server.py'",
+        ]
       working_directory: "."
       timeout_seconds: 30
 
@@ -55,12 +60,34 @@ scenarios:
 
     # Start HTTPS server before MCPSpy
     pre_commands:
-      - command: ["tests/venv/bin/python", "-m", "uvicorn", "tests.mcp_server:app", "--host", "0.0.0.0", "--port", "12345", "--ssl-keyfile=tests/server.key", "--ssl-certfile=tests/server.crt", "--log-level", "error"]
+      - command:
+          [
+            "tests/venv/bin/python",
+            "-m",
+            "uvicorn",
+            "tests.mcp_server:app",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            "12345",
+            "--ssl-keyfile=tests/server.key",
+            "--ssl-certfile=tests/server.crt",
+            "--log-level",
+            "error",
+          ]
         background: true
         wait_seconds: 3.0
 
     traffic:
-      command: ["tests/venv/bin/python", "tests/mcp_client.py", "--transport", "http", "--url", "https://127.0.0.1:12345/mcp"]
+      command:
+        [
+          "tests/venv/bin/python",
+          "tests/mcp_client.py",
+          "--transport",
+          "http",
+          "--url",
+          "https://127.0.0.1:12345/mcp",
+        ]
       timeout_seconds: 30
 
     # Stop HTTP server after test completes


### PR DESCRIPTION
Some MCP clients like Claude Code use Unix domain sockets instead of pipes for local MCP server communication. This adds support for monitoring Unix socket traffic alongside existing pipe support.

Changes:
- Add unix_sock_process_map for tracking socket endpoint processes
- Add helper functions for Unix socket detection and peer correlation
- Modify vfs_read/vfs_write hooks to handle both pipes and sockets
- Add trace_sock_release hook for proper map cleanup on socket close
- Update Go loader to attach the new cleanup hook