### PR TITLE
feat(tests): add Claude Code e2e test scenario

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,8 @@ jobs:
         run: make test-smoke
 
       - name: Run end-to-end tests
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         run: make test-e2e
 
   # Job to build cross-platform binaries as release assets

--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ test-e2e-mcp-https: test-e2e-setup ## Run e2e test without MCPSpy for HTTPS tran
 test-e2e-stdio: build test-e2e-setup ## Run end-to-end test for stdio transport
 	@echo "Running end-to-end test for stdio transport..."
 	@echo "Note: MCPSpy requires root privileges for eBPF operations"
-	sudo -E tests/venv/bin/python tests/e2e_test.py \
+	sudo -E env PATH="$$PATH" tests/venv/bin/python tests/e2e_test.py \
 		--config tests/e2e_config.yaml \
 		--scenario stdio-fastmcp
 
@@ -208,16 +208,34 @@ test-e2e-stdio: build test-e2e-setup ## Run end-to-end test for stdio transport
 test-e2e-https: build test-e2e-setup ## Run end-to-end test for HTTP transport
 	@echo "Running end-to-end test for HTTP transport..."
 	@echo "Note: MCPSpy requires root privileges for eBPF operations"
-	sudo -E tests/venv/bin/python tests/e2e_test.py \
+	sudo -E env PATH="$$PATH" tests/venv/bin/python tests/e2e_test.py \
 		--config tests/e2e_config.yaml \
 		--scenario http-fastmcp
+
+# Run e2e scenarios without MCPSpy (traffic generation only) - Claude Code
+.PHONY: test-e2e-mcp-claude
+test-e2e-mcp-claude: test-e2e-setup ## Run e2e test without MCPSpy for Claude Code
+	@echo "Running e2e test without MCPSpy for Claude Code..."
+	tests/venv/bin/python tests/e2e_test.py \
+		--config tests/e2e_config.yaml \
+		--scenario claude-code-init \
+		--skip-mcpspy
+
+# Run end-to-end test for Claude Code
+.PHONY: test-e2e-claude
+test-e2e-claude: build test-e2e-setup ## Run end-to-end test for Claude Code
+	@echo "Running end-to-end test for Claude Code..."
+	@echo "Note: MCPSpy requires root privileges for eBPF operations"
+	sudo -E env PATH="$$PATH" tests/venv/bin/python tests/e2e_test.py \
+		--config tests/e2e_config.yaml \
+		--scenario claude-code-init
 
 # Run end-to-end tests for all transports
 .PHONY: test-e2e
 test-e2e: build test-e2e-setup ## Run end-to-end tests for all transports
 	@echo "Running all end-to-end test scenarios..."
 	@echo "Note: MCPSpy requires root privileges for eBPF operations"
-	sudo -E tests/venv/bin/python tests/e2e_test.py \
+	sudo -E env PATH="$$PATH" tests/venv/bin/python tests/e2e_test.py \
 		--config tests/e2e_config.yaml
 
 # Update expected output files for stdio transport
@@ -225,7 +243,7 @@ test-e2e: build test-e2e-setup ## Run end-to-end tests for all transports
 test-e2e-update-stdio: build test-e2e-setup ## Update expected output files for stdio transport
 	@echo "Updating expected output for stdio transport..."
 	@echo "Note: MCPSpy requires root privileges for eBPF operations"
-	sudo -E tests/venv/bin/python tests/e2e_test.py \
+	sudo -E env PATH="$$PATH" tests/venv/bin/python tests/e2e_test.py \
 		--config tests/e2e_config.yaml \
 		--scenario stdio-fastmcp \
 		--update-expected
@@ -235,7 +253,7 @@ test-e2e-update-stdio: build test-e2e-setup ## Update expected output files for 
 test-e2e-update-https: build test-e2e-setup ## Update expected output files for HTTP transport
 	@echo "Updating expected output for HTTP transport..."
 	@echo "Note: MCPSpy requires root privileges for eBPF operations"
-	sudo -E tests/venv/bin/python tests/e2e_test.py \
+	sudo -E env PATH="$$PATH" tests/venv/bin/python tests/e2e_test.py \
 		--config tests/e2e_config.yaml \
 		--scenario http-fastmcp \
 		--update-expected
@@ -245,7 +263,7 @@ test-e2e-update-https: build test-e2e-setup ## Update expected output files for 
 test-e2e-update: build test-e2e-setup ## Update expected output files for all transports
 	@echo "Updating expected output for all scenarios..."
 	@echo "Note: MCPSpy requires root privileges for eBPF operations"
-	sudo -E tests/venv/bin/python tests/e2e_test.py \
+	sudo -E env PATH="$$PATH" tests/venv/bin/python tests/e2e_test.py \
 		--config tests/e2e_config.yaml \
 		--update-expected
 
@@ -255,7 +273,7 @@ test-smoke: ## Run smoke test (basic startup/shutdown test)
 	@echo "Note: MCPSpy requires root privileges for eBPF operations"
 	@chmod +x tests/smoke_test.sh
 	@chmod +x $(BUILD_DIR)/$(BINARY_NAME)-$(PLATFORM)
-	sudo -E tests/smoke_test.sh $(BUILD_DIR)/$(BINARY_NAME)-$(PLATFORM)
+	sudo -E env PATH="$$PATH" tests/smoke_test.sh $(BUILD_DIR)/$(BINARY_NAME)-$(PLATFORM)
 
 # Help
 PHONY: help

--- a/tests/claude_config.json
+++ b/tests/claude_config.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+    },
+    "deepwiki": {
+      "url": "https://mcp.deepwiki.com/mcp",
+      "type": "http"
+    }
+  }
+}

--- a/tests/e2e_config.yaml
+++ b/tests/e2e_config.yaml
@@ -99,3 +99,22 @@ scenarios:
       message_count:
         min: 20
         max: 30
+
+  # Claude Code CLI scenario
+  - name: "claude-code-init"
+    description: "Test Claude Code CLI initialization with MCP servers"
+
+    traffic:
+      # Run Claude Code with the test config - it will initialize and connect to MCP servers
+      # Provide a simple prompt and exit immediately to trigger MCP initialization
+      command:
+        [
+          "bash",
+          "-c",
+          "echo 'exit' | npx -y @anthropic-ai/claude-code --strict-mcp-config --mcp-config tests/claude_config.json 2>&1",
+        ]
+      timeout_seconds: 30
+
+    validation:
+      message_count:
+        min: 10

--- a/tests/e2e_config_schema.py
+++ b/tests/e2e_config_schema.py
@@ -136,9 +136,11 @@ class Scenario(BaseModel):
     @field_validator("validation")
     @classmethod
     def validate_expected_output_file(cls, v: ValidationConfig) -> ValidationConfig:
-        """Ensure scenario validation has expected_output_file."""
-        if v.expected_output_file is None:
-            raise ValueError("Scenario validation must specify 'expected_output_file'")
+        """Ensure scenario validation has either expected_output_file or message_count."""
+        if v.expected_output_file is None and v.message_count is None:
+            raise ValueError(
+                "Scenario validation must specify either 'expected_output_file' or 'message_count'"
+            )
         return v
 
 

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -226,6 +226,18 @@ class ValidationEngine:
 
         print(f"📊 Captured {len(captured_messages)} messages")
 
+        # Validate message count (do this first, works with or without expected file)
+        if validation_config.message_count:
+            if not self._validate_message_count(
+                len(captured_messages), validation_config.message_count
+            ):
+                return False
+
+        # If no expected output file specified, only message count validation is done
+        if not validation_config.expected_output_file:
+            print("✅ Message count validation passed (no expected file comparison)")
+            return True
+
         # Resolve expected output file path
         expected_file = Path(validation_config.expected_output_file)
         if not expected_file.is_absolute():
@@ -249,13 +261,6 @@ class ValidationEngine:
             return False
 
         print(f"📋 Expected {len(expected_messages)} messages")
-
-        # Validate message count
-        if validation_config.message_count:
-            if not self._validate_message_count(
-                len(captured_messages), validation_config.message_count
-            ):
-                return False
 
         # Validate using DeepDiff
         return self._validate_deepdiff(


### PR DESCRIPTION
Add end-to-end test infrastructure for Claude Code CLI:
- New make targets: test-e2e-mcp-claude, test-e2e-claude
- Claude Code MCP config with filesystem and deepwiki servers
- New claude-code-init scenario in e2e_config.yaml
- Relax validation schema to allow message_count-only validation
- Update validation engine to support tests without expected output files

🤖 Generated with [Claude Code](https://claude.com/claude-code)