### PR TITLE
feat(tui): add LLM API call tracing support

### DIFF
--- a/pkg/event/llm.go
+++ b/pkg/event/llm.go
@@ -27,6 +27,7 @@ type LLMEvent struct {
 	Model       string         `json:"model,omitempty"`
 	Content     string         `json:"content,omitempty"` // Request: user prompt, StreamChunk: delta, Response: full content
 	Error       string         `json:"error,omitempty"`
+	RawJSON     string         `json:"raw_json,omitempty"` // Original HTTP payload JSON (for requests/responses, not stream chunks)
 }
 
 func (e *LLMEvent) Type() EventType { return EventTypeLLMMessage }

--- a/pkg/llm/providers/anthropic.go
+++ b/pkg/llm/providers/anthropic.go
@@ -136,6 +136,7 @@ func (p *AnthropicParser) ParseRequest(req *event.HttpRequestEvent) (*event.LLME
 		Path:        req.Path,
 		Model:       anthropicReq.Model,
 		Content:     extractUserPrompt(anthropicReq.Messages),
+		RawJSON:     string(req.RequestPayload),
 	}, nil
 }
 
@@ -155,6 +156,7 @@ func (p *AnthropicParser) ParseResponse(resp *event.HttpResponseEvent) (*event.L
 		Host:        resp.Host,
 		Path:        resp.Path,
 		Model:       anthropicResp.Model,
+		RawJSON:     string(resp.ResponsePayload),
 	}
 
 	// Check for error response (type: "error" at root level)
@@ -192,6 +194,7 @@ func (p *AnthropicParser) ParseStreamEvent(sse *event.SSEEvent) (*event.LLMEvent
 		Comm:        sse.Comm(),
 		Host:        sse.Host,
 		Path:        sse.Path,
+		RawJSON:     data, // Original SSE JSON payload
 	}
 
 	// Extract model from message_start

--- a/pkg/llm/providers/gemini.go
+++ b/pkg/llm/providers/gemini.go
@@ -90,6 +90,7 @@ func (p *GeminiParser) ParseRequest(req *event.HttpRequestEvent) (*event.LLMEven
 		Path:        req.Path,
 		Model:       model,
 		Content:     extractGeminiUserPrompt(geminiReq.Contents),
+		RawJSON:     string(req.RequestPayload),
 	}, nil
 }
 
@@ -115,6 +116,7 @@ func (p *GeminiParser) ParseResponse(resp *event.HttpResponseEvent) (*event.LLME
 		Host:        resp.Host,
 		Path:        resp.Path,
 		Model:       model,
+		RawJSON:     string(resp.ResponsePayload),
 	}
 
 	// Check for error response
@@ -156,6 +158,7 @@ func (p *GeminiParser) ParseStreamEvent(sse *event.SSEEvent) (*event.LLMEvent, b
 		Host:        sse.Host,
 		Path:        sse.Path,
 		Model:       model,
+		RawJSON:     data, // Original SSE JSON payload
 	}
 
 	// Check for error

--- a/tests/e2e_config.yaml
+++ b/tests/e2e_config.yaml
@@ -148,6 +148,8 @@ scenarios:
           - "root\\[\\d+\\]\\['timestamp'\\]"
           - "root\\[\\d+\\]\\['session_id'\\]"
           - "root\\[\\d+\\]\\['pid'\\]"
+          # Exclude raw JSON field (contains full API payload)
+          - "root\\[\\d+\\]\\['raw_json'\\]"
 
   # LLM API monitoring scenario (Gemini)
   # This test requires GEMINI_API_KEY environment variable to be set
@@ -178,6 +180,8 @@ scenarios:
           - "root\\[\\d+\\]\\['timestamp'\\]"
           - "root\\[\\d+\\]\\['session_id'\\]"
           - "root\\[\\d+\\]\\['pid'\\]"
+          # Exclude raw JSON field (contains full API payload)
+          - "root\\[\\d+\\]\\['raw_json'\\]"
 
   # Security/Prompt Injection detection scenario
   # This test requires HF_TOKEN environment variable to be set


### PR DESCRIPTION
## Summary
- Add LLM API call tracing to the TUI with dedicated APP column (MCP/LLM)
- Support for Anthropic and Gemini API monitoring with stream chunks
- Store original HTTP/SSE payloads in RawJSON field for accurate detail view
- Add STREAM to type filter cycle for filtering stream events
- Color-coded APP column (Sky Blue for MCP, Orchid for LLM)

## Test plan
- [x] Unit tests pass
- [x] E2E tests pass (6/6 scenarios)
- [x] Verify LLM requests/responses appear in TUI
- [x] Verify stream chunks display with original SSE JSON
- [x] Test type filter cycling includes STREAM option

🤖 Generated with [Claude Code](https://claude.com/claude-code)