### PR TITLE
chore(makefile): refactor test targets with clearer naming convention

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -104,12 +104,12 @@ make test-e2e-https
 make test-e2e
 ```
 
-Running solely the mcp e2e tests (without mcpspy):
+Running scenario tests (without mcpspy):
 
 ```bash
-make test-e2e-mcp-stdio
-make test-e2e-mcp-https
-make test-e2e-mcp-security  # Security/injection test
+make test-scenario-stdio
+make test-scenario-https
+make test-scenario-security  # Security/injection test
 ```
 
 **Note:** E2E tests automatically run MCPSpy in static mode (`--tui=false`) to capture output for validation. The test configuration is in `tests/e2e_config.yaml`.
@@ -119,11 +119,8 @@ make test-e2e-mcp-security  # Security/injection test
 Integration tests verify functionality with real external services. Currently includes security/prompt injection detection tests with HuggingFace API:
 
 ```bash
-# Run all integration tests (requires HF_TOKEN)
+# Run integration tests (requires HF_TOKEN)
 HF_TOKEN=hf_xxx make test-integration
-
-# Run only security integration tests
-HF_TOKEN=hf_xxx make test-integration-security
 
 # Override the model (default: protectai/deberta-v3-base-prompt-injection-v2)
 HF_TOKEN=hf_xxx HF_MODEL=your-model-name make test-integration

--- a/.claude/skills/security-integration-tests.md/SKILL.md
+++ b/.claude/skills/security-integration-tests.md/SKILL.md
@@ -22,10 +22,10 @@ The security package (`pkg/security/`) provides prompt injection detection using
 
 ```bash
 # Run integration tests (requires HF_TOKEN environment variable)
-HF_TOKEN=hf_xxx make test-security-integration
+HF_TOKEN=hf_xxx make test-integration
 
 # Run with custom model
-HF_TOKEN=hf_xxx HF_MODEL=protectai/deberta-v3-base-prompt-injection-v2 make test-security-integration
+HF_TOKEN=hf_xxx HF_MODEL=protectai/deberta-v3-base-prompt-injection-v2 make test-integration
 
 # Run unit tests only (no API calls, uses mock server)
 go test -v ./pkg/security/...

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,88 +1,10 @@
 # MCPSpy Project Rules
 
-## Project Overview
-
-MCPSpy is a CLI utility that uses eBPF to monitor MCP (Model Context Protocol) communication by tracking stdio operations and analyzing JSON-RPC 2.0 messages.
-
-## Technology Stack
-
-- Go 1.24+ for the main application
-- C for eBPF programs
-- cilium/ebpf for loading eBPF programs
-- Docker for containerization
-
-## Project Structure
-
-```
-mcpspy/
-├── cmd/mcpspy/          # CLI entry point
-├── pkg/
-│   ├── ebpf/            # eBPF loading and management
-│   ├── event/           # Event definitions and handling
-|   |── http/            # HTTP transport parsing and analysis
-│   ├── mcp/             # MCP protocol parsing and analysis
-│   └── output/          # Output formatting (console, and file output)
-├── bpf/                 # eBPF C programs
-├── tests/               # Test files
-├── deploy/docker/  # Docker configuration
-└── .github/workflows/   # CI/CD workflows
-```
-
-## MCP Protocol Context
-
-- MCP uses JSON-RPC 2.0 format
-- Messages have jsonrpc: "2.0" field
-- Three message types: Request, Response, Notification
-- Track method names like "tools/call", "resources/read", etc.
-- Focus on both stdio and HTTP transport (streamable HTTP).
-
-## Performance Guidelines
-
-- Use efficient data structures
-- Minimize data copying between kernel and userspace
-- Filter early in eBPF to reduce overhead
-
-## Building
-
-```bash
-make build
-```
-
-## Running
-
-```bash
-sudo ./mcpspy
-
-# It is must be stopped by sending SIGINT (Ctrl+C) or SIGTERM.
-```
-
-## Testing
-
-Running all tests (unit tests, and end-to-end tests for both stdio and https transports):
-
-```bash
-make test
-```
-
-Running unit tests:
-
-```bash
-make test-unit
-```
-
-Running end-to-end tests (including mcpspy, and verifying the output):
-
-```bash
-make test-e2e-stdio
-make test-e2e-https
-
-# Or
-make test-e2e
-```
-
-Running solely the mcp e2e tests (without mcpspy):
-
-```bash
-make test-e2e-mcp-stdio
-make test-e2e-mcp-https
-```
+See `.claude/CLAUDE.md` for complete project documentation including:
+- Project overview and architecture
+- Technology stack
+- Project structure
+- Building and running instructions
+- Testing commands
+- Integration tests
+- Git worktree workflow

--- a/Makefile
+++ b/Makefile
@@ -50,28 +50,58 @@ GO_BIN_DIR := $(shell go env GOPATH)/bin
 # Binary naming with platform suffix
 BINARY_OUTPUT := $(BUILD_DIR)/$(BINARY_NAME)-$(PLATFORM)
 
+# =============================================================================
+# Test Functions
+# =============================================================================
+# These functions reduce duplication across test targets
+
+# Run scenario only (no MCPSpy)
+# $(1) = scenario name
+define run-scenario
+	tests/venv/bin/python tests/e2e_test.py \
+		--config tests/e2e_config.yaml \
+		--scenario $(1) \
+		--skip-mcpspy
+endef
+
+# Run e2e test with MCPSpy
+# $(1) = scenario name
+define run-e2e
+	tests/venv/bin/python tests/e2e_test.py \
+		--config tests/e2e_config.yaml \
+		--scenario $(1)
+endef
+
+# Update expected output for e2e test
+# $(1) = scenario name
+define run-update
+	tests/venv/bin/python tests/e2e_test.py \
+		--config tests/e2e_config.yaml \
+		--scenario $(1) \
+		--update-expected
+endef
+
+# =============================================================================
 ##@ Build Targets
+# =============================================================================
 
-# Default target
 .PHONY: all
-all: generate build ## Building everything (default target)
+all: generate build ## Build everything (default target)
 
-# Generate eBPF Go bindings
 .PHONY: generate
 generate: ## Generate eBPF Go bindings
 	@echo "Generating eBPF Go bindings..."
 	cd pkg/ebpf && MCPSPY_TRACE_LOG=$(MCPSPY_TRACE_LOG) go generate
 
-# Build the binary
 .PHONY: build
-build: generate	## Build the binary for current platform
+build: generate ## Build the binary for current platform
 	@echo "Building $(BINARY_NAME) for $(PLATFORM)..."
 	@mkdir -p $(BUILD_DIR)
 	@GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(BUILD_FLAGS) -o $(BINARY_OUTPUT) ./cmd/mcpspy
 	@echo "Binary built: $(BINARY_OUTPUT)"
 
 .PHONY: build-platforms
-build-platforms: generate ## Build the binaries for all supported platforms
+build-platforms: generate ## Build binaries for all supported platforms
 	@echo "Building $(BINARY_NAME) for all platforms..."
 	@mkdir -p $(BUILD_DIR)
 	@for platform in $(PLATFORMS); do \
@@ -84,7 +114,7 @@ build-platforms: generate ## Build the binaries for all supported platforms
 	@echo "All binaries built successfully!"
 
 .PHONY: checksums
-checksums: ## Generate sha256 checksums for all built binaries (relative to build/)
+checksums: ## Generate sha256 checksums for all built binaries
 	@echo "Generating checksums..."
 	@cd $(BUILD_DIR) && \
 	for platform in $(PLATFORMS); do \
@@ -99,13 +129,10 @@ checksums: ## Generate sha256 checksums for all built binaries (relative to buil
 .PHONY: release-assets
 release-assets: build-platforms checksums ## Build binaries and generate checksums
 
-# Build Docker image for current platform (optional, CI handles multi-platform)
 .PHONY: image
-image: build ## Build Docker image for current platform (local development)
+image: build checksums ## Build Docker image for current platform
 	@echo "Building Docker image for $(PLATFORM)..."
-	# Check checksum
 	@sha256sum -c $(BINARY_OUTPUT).sha256sum || exit 1
-	# Copy the binary from the build directory to the current directory
 	@cp $(BINARY_OUTPUT) ./mcpspy
 	@if docker buildx version >/dev/null 2>&1; then \
         echo "Using Docker Buildx for current platform..."; \
@@ -116,67 +143,49 @@ image: build ## Build Docker image for current platform (local development)
     fi;
 	@echo "Docker image built: $(DOCKER_IMAGE):$(IMAGE_TAG)"
 
-##@ Test Targets
+# =============================================================================
+##@ Development Tools
+# =============================================================================
 
-# Clean test environment
-.PHONY: test-e2e-clean
-test-e2e-clean: ## Clean Python e2e test environment
-	@echo "Cleaning test environment..."
-	rm -rf tests/venv
-
-# Clean build artifacts
-.PHONY: clean
-clean: ## Clean build artifacts
-	@echo "Cleaning..."
-	rm -rf $(BUILD_DIR)
-	rm -f pkg/ebpf/mcpspy_bpfe*.go
-	rm -f pkg/ebpf/mcpspy_bpfe*.o
-
-# Install dependencies
 .PHONY: deps
-deps: ## Install dependencies
+deps: ## Install Go dependencies
 	@echo "Installing dependencies..."
 	$(GO) mod download
 	$(GO) mod tidy
 
-PHONY: go-tools
+.PHONY: go-tools
 go-tools: ## Install Go development tools (golangci-lint, bpf2go)
 	@echo "Installing Go development tools..."
 	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 	$(GO) install github.com/cilium/ebpf/cmd/bpf2go@latest
 	@echo "Please ensure $(GO_BIN_DIR) is in your PATH for local development."
 
-# Format code
 .PHONY: fmt
-fmt: ## Format code
+fmt: ## Format Go and BPF code
 	@echo "Formatting code..."
 	$(GO) fmt ./...
 	$(CLANG_FORMAT) --verbose -i --Werror -style="{IndentWidth: 4}" $(BPF_SRCS)
 
-# Run linters
 .PHONY: lint
 lint: generate ## Run linters
 	@echo "Running linters..."
 	$(GO_BIN_DIR)/$(GOLANGCI_LINT) run --disable=errcheck
 
-# Run all tests (unit and e2e for both transports)
-.PHONY: test
-test: test-unit test-e2e ## Run all tests (unit and e2e for both transports)
+# =============================================================================
+##@ Unit & Integration Tests
+# =============================================================================
 
-# Run unit tests only
+.PHONY: test
+test: test-unit test-e2e ## Run all tests (unit and e2e)
+
 .PHONY: test-unit
 test-unit: ## Run unit tests
 	@echo "Running unit tests..."
 	$(GO) test $(TEST_FLAGS) ./...
 
-# Run all integration tests
 .PHONY: test-integration
-test-integration: test-integration-security ## Run all integration tests (requires HF_TOKEN)
-
-# Run security integration tests (requires HF_TOKEN)
-.PHONY: test-integration-security
-test-integration-security: ## Run security integration tests with real HuggingFace API (requires HF_TOKEN)
-	@echo "Running security integration tests..."
+test-integration: ## Run integration tests (requires HF_TOKEN)
+	@echo "Running integration tests..."
 	@if [ -z "$$HF_TOKEN" ]; then \
 		echo "Error: HF_TOKEN environment variable is not set"; \
 		echo "Usage: HF_TOKEN=hf_xxx make test-integration"; \
@@ -184,191 +193,152 @@ test-integration-security: ## Run security integration tests with real HuggingFa
 	fi
 	$(GO) test -v -tags=integration -timeout=300s ./pkg/security/...
 
-# Setup e2e test environment
+# =============================================================================
+##@ Test Setup & Utilities
+# =============================================================================
+
 .PHONY: test-e2e-setup
 test-e2e-setup: ## Setup Python e2e test environment
 	@echo "Setting up test environment..."
 	@$(PYTHON) -m venv tests/venv || true
 	tests/venv/bin/pip install -r tests/requirements.txt
 
-# Run e2e scenarios without MCPSpy (traffic generation only) - stdio transport
-.PHONY: test-e2e-mcp-stdio
-test-e2e-mcp-stdio: test-e2e-setup ## Run e2e test without MCPSpy for stdio transport
-	@echo "Running e2e test without MCPSpy for stdio transport..."
-	tests/venv/bin/python tests/e2e_test.py \
-		--config tests/e2e_config.yaml \
-		--scenario stdio-fastmcp \
-		--skip-mcpspy
-
-# Run e2e scenarios without MCPSpy (traffic generation only) - HTTPS transport
-.PHONY: test-e2e-mcp-https
-test-e2e-mcp-https: test-e2e-setup ## Run e2e test without MCPSpy for HTTPS transport
-	@echo "Running e2e test without MCPSpy for HTTPS transport..."
-	tests/venv/bin/python tests/e2e_test.py \
-		--config tests/e2e_config.yaml \
-		--scenario http-fastmcp \
-		--skip-mcpspy
-
-# Run e2e scenarios without MCPSpy (traffic generation only) - security test
-.PHONY: test-e2e-mcp-security
-test-e2e-mcp-security: test-e2e-setup ## Run security e2e test without MCPSpy (traffic generation only)
-	@echo "Running security e2e test without MCPSpy..."
-	tests/venv/bin/python tests/e2e_test.py \
-		--config tests/e2e_config.yaml \
-		--scenario security-injection \
-		--skip-mcpspy
-
-# Run end-to-end test for stdio transport
-.PHONY: test-e2e-stdio
-test-e2e-stdio: build test-e2e-setup ## Run end-to-end test for stdio transport
-	@echo "Running end-to-end test for stdio transport..."
-	@echo "Note: MCPSpy requires root privileges for eBPF operations (uses sudo -n internally)"
-	tests/venv/bin/python tests/e2e_test.py \
-		--config tests/e2e_config.yaml \
-		--scenario stdio-fastmcp
-
-# Run end-to-end test for HTTP transport
-.PHONY: test-e2e-https
-test-e2e-https: build test-e2e-setup ## Run end-to-end test for HTTP transport
-	@echo "Running end-to-end test for HTTP transport..."
-	@echo "Note: MCPSpy requires root privileges for eBPF operations (uses sudo -n internally)"
-	tests/venv/bin/python tests/e2e_test.py \
-		--config tests/e2e_config.yaml \
-		--scenario http-fastmcp
-
-# Run e2e scenario without MCPSpy (traffic generation only) - Claude Code
-.PHONY: test-e2e-mcp-claude
-test-e2e-mcp-claude: test-e2e-setup ## Run e2e test without MCPSpy for Claude Code (MCP + tools + LLM)
-	@echo "Running e2e test without MCPSpy for Claude Code..."
-	tests/venv/bin/python tests/e2e_test.py \
-		--config tests/e2e_config.yaml \
-		--scenario claude-code \
-		--skip-mcpspy
-
-# Run end-to-end test for Claude Code (MCP + tools + LLM)
-.PHONY: test-e2e-claude
-test-e2e-claude: build test-e2e-setup ## Run end-to-end test for Claude Code (MCP + tools + LLM)
-	@echo "Running end-to-end test for Claude Code..."
-	@echo "Note: MCPSpy requires root privileges for eBPF operations (uses sudo -n internally)"
-	tests/venv/bin/python tests/e2e_test.py \
-		--config tests/e2e_config.yaml \
-		--scenario claude-code
-
-# Run end-to-end tests for all transports
-.PHONY: test-e2e
-test-e2e: build test-e2e-setup ## Run end-to-end tests for all transports
-	@echo "Running all end-to-end test scenarios..."
-	@echo "Note: MCPSpy requires root privileges for eBPF operations (uses sudo -n internally)"
-	tests/venv/bin/python tests/e2e_test.py \
-		--config tests/e2e_config.yaml
-
-# Update expected output files for stdio transport
-.PHONY: test-e2e-update-stdio
-test-e2e-update-stdio: build test-e2e-setup ## Update expected output files for stdio transport
-	@echo "Updating expected output for stdio transport..."
-	@echo "Note: MCPSpy requires root privileges for eBPF operations (uses sudo -n internally)"
-	tests/venv/bin/python tests/e2e_test.py \
-		--config tests/e2e_config.yaml \
-		--scenario stdio-fastmcp \
-		--update-expected
-
-# Update expected output files for HTTP transport
-.PHONY: test-e2e-update-https
-test-e2e-update-https: build test-e2e-setup ## Update expected output files for HTTP transport
-	@echo "Updating expected output for HTTP transport..."
-	@echo "Note: MCPSpy requires root privileges for eBPF operations (uses sudo -n internally)"
-	tests/venv/bin/python tests/e2e_test.py \
-		--config tests/e2e_config.yaml \
-		--scenario http-fastmcp \
-		--update-expected
-
-# Update expected output files for all transports
-.PHONY: test-e2e-update
-test-e2e-update: build test-e2e-setup ## Update expected output files for all transports
-	@echo "Updating expected output for all scenarios..."
-	@echo "Note: MCPSpy requires root privileges for eBPF operations (uses sudo -n internally)"
-	tests/venv/bin/python tests/e2e_test.py \
-		--config tests/e2e_config.yaml \
-		--update-expected
-
-# Run security E2E test (requires HF_TOKEN environment variable)
-.PHONY: test-e2e-security
-test-e2e-security: build test-e2e-setup ## Run security/prompt injection E2E test (requires HF_TOKEN)
-	@echo "Running security E2E test..."
-	@echo "Note: Requires HF_TOKEN environment variable and root privileges (uses sudo -n internally)"
-	@if [ -z "$$HF_TOKEN" ]; then echo "ERROR: HF_TOKEN environment variable is required"; exit 1; fi
-	tests/venv/bin/python tests/e2e_test.py \
-		--config tests/e2e_config.yaml \
-		--scenario security-injection
-
-# Run e2e scenarios without MCPSpy (traffic generation only) - LLM Anthropic
-.PHONY: test-e2e-mcp-llm
-test-e2e-mcp-llm: test-e2e-setup ## Run LLM e2e test without MCPSpy (traffic generation only, requires CLAUDE_CODE_OAUTH_TOKEN)
-	@echo "Running LLM e2e test without MCPSpy..."
-	tests/venv/bin/python tests/e2e_test.py \
-		--config tests/e2e_config.yaml \
-		--scenario llm-anthropic \
-		--skip-mcpspy
-
-# Run LLM E2E test (requires CLAUDE_CODE_OAUTH_TOKEN environment variable)
-.PHONY: test-e2e-llm
-test-e2e-llm: build test-e2e-setup ## Run LLM API monitoring E2E test (requires CLAUDE_CODE_OAUTH_TOKEN)
-	@echo "Running LLM E2E test..."
-	@echo "Note: MCPSpy requires root privileges for eBPF operations (uses sudo -n internally)"
-	tests/venv/bin/python tests/e2e_test.py \
-		--config tests/e2e_config.yaml \
-		--scenario llm-anthropic
-
-# Update expected output files for LLM scenario
-.PHONY: test-e2e-update-llm
-test-e2e-update-llm: build test-e2e-setup ## Update expected output files for LLM scenario (requires CLAUDE_CODE_OAUTH_TOKEN)
-	@echo "Updating expected output for LLM scenario..."
-	@echo "Note: MCPSpy requires root privileges for eBPF operations (uses sudo -n internally)"
-	tests/venv/bin/python tests/e2e_test.py \
-		--config tests/e2e_config.yaml \
-		--scenario llm-anthropic \
-		--update-expected
-
-# Run Gemini LLM e2e test without MCPSpy (traffic generation only)
-.PHONY: test-e2e-mcp-llm-gemini
-test-e2e-mcp-llm-gemini: test-e2e-setup ## Run Gemini LLM e2e test without MCPSpy (requires GEMINI_API_KEY)
-	@echo "Running Gemini LLM e2e test without MCPSpy..."
-	tests/venv/bin/python tests/e2e_test.py \
-		--config tests/e2e_config.yaml \
-		--scenario llm-gemini \
-		--skip-mcpspy
-
-# Run Gemini LLM E2E test (requires GEMINI_API_KEY environment variable)
-.PHONY: test-e2e-llm-gemini
-test-e2e-llm-gemini: build test-e2e-setup ## Run Gemini LLM API monitoring E2E test (requires GEMINI_API_KEY)
-	@echo "Running Gemini LLM E2E test..."
-	@echo "Note: MCPSpy requires root privileges for eBPF operations (uses sudo -n internally)"
-	tests/venv/bin/python tests/e2e_test.py \
-		--config tests/e2e_config.yaml \
-		--scenario llm-gemini
-
-# Update expected output files for Gemini LLM scenario
-.PHONY: test-e2e-update-llm-gemini
-test-e2e-update-llm-gemini: build test-e2e-setup ## Update expected output files for Gemini LLM scenario (requires GEMINI_API_KEY)
-	@echo "Updating expected output for Gemini LLM scenario..."
-	@echo "Note: MCPSpy requires root privileges for eBPF operations (uses sudo -n internally)"
-	tests/venv/bin/python tests/e2e_test.py \
-		--config tests/e2e_config.yaml \
-		--scenario llm-gemini \
-		--update-expected
+.PHONY: test-e2e-clean
+test-e2e-clean: ## Clean Python e2e test environment
+	@echo "Cleaning test environment..."
+	rm -rf tests/venv
 
 .PHONY: test-smoke
-test-smoke: ## Run smoke test (basic startup/shutdown test)
+test-smoke: ## Run smoke test (basic startup/shutdown)
 	@echo "Running smoke test..."
-	@echo "Note: MCPSpy requires root privileges for eBPF operations (uses sudo -n internally)"
 	@chmod +x tests/smoke_test.sh
 	@chmod +x $(BUILD_DIR)/$(BINARY_NAME)-$(PLATFORM)
 	tests/smoke_test.sh $(BUILD_DIR)/$(BINARY_NAME)-$(PLATFORM)
 
-# Help
-PHONY: help
+# =============================================================================
+##@ Scenario Tests (no MCPSpy)
+# =============================================================================
+
+.PHONY: test-scenario-stdio
+test-scenario-stdio: test-e2e-setup ## Run stdio scenario (no MCPSpy)
+	@echo "Running stdio scenario..."
+	$(call run-scenario,stdio-fastmcp)
+
+.PHONY: test-scenario-https
+test-scenario-https: test-e2e-setup ## Run HTTPS scenario (no MCPSpy)
+	@echo "Running HTTPS scenario..."
+	$(call run-scenario,http-fastmcp)
+
+.PHONY: test-scenario-claudecode
+test-scenario-claudecode: test-e2e-setup ## Run Claude Code scenario (no MCPSpy)
+	@echo "Running Claude Code scenario..."
+	$(call run-scenario,claude-code-init)
+
+.PHONY: test-scenario-llm-anthropic
+test-scenario-llm-anthropic: test-e2e-setup ## Run Anthropic LLM scenario (no MCPSpy, requires CLAUDE_CODE_OAUTH_TOKEN)
+	@echo "Running Anthropic LLM scenario..."
+	$(call run-scenario,llm-anthropic)
+
+.PHONY: test-scenario-llm-gemini
+test-scenario-llm-gemini: test-e2e-setup ## Run Gemini LLM scenario (no MCPSpy, requires GEMINI_API_KEY)
+	@echo "Running Gemini LLM scenario..."
+	$(call run-scenario,llm-gemini)
+
+.PHONY: test-scenario-security
+test-scenario-security: test-e2e-setup ## Run security scenario (no MCPSpy)
+	@echo "Running security scenario..."
+	$(call run-scenario,security-injection)
+
+# =============================================================================
+##@ E2E Tests (with MCPSpy)
+# =============================================================================
+
+.PHONY: test-e2e-stdio
+test-e2e-stdio: build test-e2e-setup ## Run e2e test for stdio transport
+	@echo "Running e2e test for stdio transport..."
+	$(call run-e2e,stdio-fastmcp)
+
+.PHONY: test-e2e-https
+test-e2e-https: build test-e2e-setup ## Run e2e test for HTTPS transport
+	@echo "Running e2e test for HTTPS transport..."
+	$(call run-e2e,http-fastmcp)
+
+.PHONY: test-e2e-claudecode
+test-e2e-claudecode: build test-e2e-setup ## Run e2e test for Claude Code
+	@echo "Running e2e test for Claude Code..."
+	$(call run-e2e,claude-code-init)
+
+.PHONY: test-e2e-llm-anthropic
+test-e2e-llm-anthropic: build test-e2e-setup ## Run e2e test for Anthropic LLM (requires CLAUDE_CODE_OAUTH_TOKEN)
+	@echo "Running Anthropic LLM e2e test..."
+	$(call run-e2e,llm-anthropic)
+
+.PHONY: test-e2e-llm-gemini
+test-e2e-llm-gemini: build test-e2e-setup ## Run e2e test for Gemini LLM (requires GEMINI_API_KEY)
+	@echo "Running Gemini LLM e2e test..."
+	$(call run-e2e,llm-gemini)
+
+.PHONY: test-e2e-security
+test-e2e-security: build test-e2e-setup ## Run e2e test for security (requires HF_TOKEN)
+	@echo "Running security e2e test..."
+	@if [ -z "$$HF_TOKEN" ]; then echo "ERROR: HF_TOKEN environment variable is required"; exit 1; fi
+	$(call run-e2e,security-injection)
+
+.PHONY: test-e2e
+test-e2e: build test-e2e-setup ## Run all e2e test scenarios
+	@echo "Running all e2e test scenarios..."
+	tests/venv/bin/python tests/e2e_test.py \
+		--config tests/e2e_config.yaml
+
+# =============================================================================
+##@ Update Expected Output
+# =============================================================================
+
+.PHONY: test-update-stdio
+test-update-stdio: build test-e2e-setup ## Update expected output for stdio
+	@echo "Updating expected output for stdio..."
+	$(call run-update,stdio-fastmcp)
+
+.PHONY: test-update-https
+test-update-https: build test-e2e-setup ## Update expected output for HTTPS
+	@echo "Updating expected output for HTTPS..."
+	$(call run-update,http-fastmcp)
+
+.PHONY: test-update-llm-anthropic
+test-update-llm-anthropic: build test-e2e-setup ## Update expected output for Anthropic LLM
+	@echo "Updating expected output for Anthropic LLM..."
+	$(call run-update,llm-anthropic)
+
+.PHONY: test-update-llm-gemini
+test-update-llm-gemini: build test-e2e-setup ## Update expected output for Gemini LLM
+	@echo "Updating expected output for Gemini LLM..."
+	$(call run-update,llm-gemini)
+
+.PHONY: test-update-all
+test-update-all: build test-e2e-setup ## Update expected output for all scenarios
+	@echo "Updating expected output for all scenarios..."
+	tests/venv/bin/python tests/e2e_test.py \
+		--config tests/e2e_config.yaml \
+		--update-expected
+
+# =============================================================================
+##@ Cleanup
+# =============================================================================
+
+.PHONY: clean
+clean: ## Clean build artifacts
+	@echo "Cleaning..."
+	rm -rf $(BUILD_DIR)
+	rm -f pkg/ebpf/mcpspy_bpfe*.go
+	rm -f pkg/ebpf/mcpspy_bpfe*.o
+
+# =============================================================================
+##@ Help
+# =============================================================================
+
+.PHONY: help
 help: ## Display this help message
 	@awk 'BEGIN {FS = ":.*##"; printf "\n\033[1m%s\033[0m\n", "Usage: make <target>"} \
-		/^[a-zA-Z0-9_-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 } \
+		/^[a-zA-Z0-9_-]+:.*?##/ { printf "  \033[36m%-30s\033[0m %s\n", $$1, $$2 } \
 		/^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } \
 		' $(MAKEFILE_LIST)

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -15,20 +15,14 @@ make test-e2e-stdio      # Stdio transport
 make test-e2e-https      # HTTPS transport
 ```
 
-### Run Specific Transport without MCPSpy
+### Run Scenario Only (no MCPSpy)
 
 ```bash
-make test-e2e-mcp-stdio      # Stdio transport
-make test-e2e-mcp-https      # HTTPS transport
-make test-e2e-mcp-security   # Security/injection test
-make test-e2e-mcp-llm        # LLM API monitoring test
-make test-e2e-mcp-claude     # Claude Code (MCP + tools + LLM)
-```
-
-### Run Claude Code E2E Test
-
-```bash
-make test-e2e-claude  # Comprehensive test: MCP + tool usage + LLM API
+make test-scenario-stdio          # Stdio transport
+make test-scenario-https          # HTTPS transport
+make test-scenario-security       # Security/injection test
+make test-scenario-llm-anthropic  # Anthropic LLM API test
+make test-scenario-llm-gemini     # Gemini LLM API test
 ```
 
 ### Run Security/Prompt Injection E2E Test
@@ -39,32 +33,28 @@ Requires `HF_TOKEN` environment variable:
 HF_TOKEN=your_huggingface_token make test-e2e-security
 ```
 
-Update expected output:
+### Run LLM API Monitoring E2E Tests
+
+**Anthropic Claude API** (requires `CLAUDE_CODE_OAUTH_TOKEN`):
 
 ```bash
-HF_TOKEN=your_token make test-e2e-update-security
+CLAUDE_CODE_OAUTH_TOKEN=your_api_key make test-e2e-llm-anthropic
 ```
 
-### Run LLM API Monitoring E2E Test
-
-Requires `CLAUDE_CODE_OAUTH_TOKEN` environment variable:
+**Google Gemini API** (requires `GEMINI_API_KEY`):
 
 ```bash
-CLAUDE_CODE_OAUTH_TOKEN=your_api_key make test-e2e-llm
-```
-
-Update expected output:
-
-```bash
-CLAUDE_CODE_OAUTH_TOKEN=your_api_key make test-e2e-update-llm
+GEMINI_API_KEY=your_api_key make test-e2e-llm-gemini
 ```
 
 ### Update Expected Outputs
 
 ```bash
-make test-e2e-update              # All scenarios
-make test-e2e-update-stdio        # Specific scenario
-make test-e2e-update-https
+make test-update-all              # All scenarios
+make test-update-stdio            # Specific scenario
+make test-update-https
+make test-update-llm-anthropic
+make test-update-llm-gemini
 ```
 
 ---
@@ -93,11 +83,11 @@ python tests/e2e_test.py --config tests/e2e_config.yaml --verbose
 
 | Argument            | Type   | Required | Description                                                                                                           |
 | ------------------- | ------ | -------- | --------------------------------------------------------------------------------------------------------------------- |
-| `--config`          | Path   | ✅ Yes   | Path to YAML configuration file                                                                                       |
-| `--scenario`        | String | ❌ No    | Run specific scenario by name (default: all scenarios)                                                                |
-| `--update-expected` | Flag   | ❌ No    | Update expected output files instead of validating                                                                    |
-| `--verbose`, `-v`   | Flag   | ❌ No    | Enable verbose logging output                                                                                         |
-| `--skip-mcpspy`     | Flag   | ❌ No    | Skip MCPSpy monitoring - only run traffic generation and pre/post commands (useful for debugging MCP implementations) |
+| `--config`          | Path   | Yes      | Path to YAML configuration file                                                                                       |
+| `--scenario`        | String | No       | Run specific scenario by name (default: all scenarios)                                                                |
+| `--update-expected` | Flag   | No       | Update expected output files instead of validating                                                                    |
+| `--verbose`, `-v`   | Flag   | No       | Enable verbose logging output                                                                                         |
+| `--skip-mcpspy`     | Flag   | No       | Skip MCPSpy monitoring - only run traffic generation and pre/post commands (useful for debugging MCP implementations) |
 
 ---
 


### PR DESCRIPTION
## Summary
- Refactored Makefile test targets with a clearer naming convention:
  - `test-scenario-*` for scenario-only tests (no MCPSpy)
  - `test-e2e-*` for full e2e tests (with MCPSpy)
  - `test-update-*` for updating expected output files
- Added make functions to reduce duplication across test targets
- Fixed syntax errors and improved organization
- Consolidated `test-integration-security` into single `test-integration` target
- Updated all documentation to reflect new target names

## Test plan
- [x] Verify `make help` displays organized sections correctly
- [x] Verify `make test-unit` passes
- [x] Verify `make test-e2e` runs all e2e test scenarios
- [x] Verify individual e2e tests work with new target names (`test-e2e-stdio`, `test-e2e-https`, etc.)
- [x] Verify scenario tests work (`test-scenario-stdio`, `test-scenario-https`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)