### PR TITLE
fix: missing OPENAI_API_KEY in PR workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,13 +62,14 @@ jobs:
 
       - name: Run end-to-end tests
         # E2E tests run all scenarios. Scenarios that require secrets
-        # (CLAUDE_CODE_OAUTH_TOKEN, GEMINI_API_KEY, HF_TOKEN) will be
+        # (CLAUDE_CODE_OAUTH_TOKEN, GEMINI_API_KEY, HF_TOKEN, OPENAI_API_KEY) will be
         # skipped with a warning if the secrets are not available.
         # This allows PRs from forks to pass CI without access to secrets.
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: make test-e2e
 
   # Job to build cross-platform binaries as release assets


### PR DESCRIPTION
The codex-cli and llm-openai E2E test scenarios added in PR #107 require the OPENAI_API_KEY environment variable. This was missing from the CI workflow, causing those tests to fail.