### PR TITLE
feat(tui): add tool usage event display support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -232,7 +232,7 @@ test-scenario-https: test-e2e-setup ## Run HTTPS scenario (no MCPSpy)
 .PHONY: test-scenario-claudecode
 test-scenario-claudecode: test-e2e-setup ## Run Claude Code scenario (no MCPSpy)
 	@echo "Running Claude Code scenario..."
-	$(call run-scenario,claude-code-init)
+	$(call run-scenario,claude-code)
 
 .PHONY: test-scenario-llm-anthropic
 test-scenario-llm-anthropic: test-e2e-setup ## Run Anthropic LLM scenario (no MCPSpy, requires CLAUDE_CODE_OAUTH_TOKEN)
@@ -281,7 +281,7 @@ test-e2e-https: build test-e2e-setup ## Run e2e test for HTTPS transport
 .PHONY: test-e2e-claudecode
 test-e2e-claudecode: build test-e2e-setup ## Run e2e test for Claude Code
 	@echo "Running e2e test for Claude Code..."
-	$(call run-e2e,claude-code-init)
+	$(call run-e2e,claude-code)
 
 .PHONY: test-e2e-llm-anthropic
 test-e2e-llm-anthropic: build test-e2e-setup ## Run e2e test for Anthropic LLM (requires CLAUDE_CODE_OAUTH_TOKEN)


### PR DESCRIPTION
## Summary

- Add TUI support for displaying tool usage events (CALL and RESULT types)
- Add new "TOOL" filter option in the app filter (alongside MCP and LLM)
- Add invocation/result tab navigation for tool events in detail view
- Implement tool-to-result mapping for correlation display
- Update Makefile with tool-related targets

## Test plan

- [ ] Run `make test-unit` to verify no regressions
- [ ] Run `make build && sudo ./mcpspy` and verify tool events appear in TUI
- [ ] Test filtering by TOOL type using 'a' key
- [ ] Test detail view tabs (t key) for tool events

🤖 Generated with [Claude Code](https://claude.com/claude-code)