### PR TITLE
fix(e2e): add required_env_vars to Claude Code and Gemini CLI scenarios

### DIFF
--- a/tests/e2e_config.yaml
+++ b/tests/e2e_config.yaml
@@ -101,8 +101,10 @@ scenarios:
         max: 30
 
   # Claude Code CLI scenario - comprehensive test for MCP, tools, and LLM
+  # This test requires ANTHROPIC_API_KEY environment variable to be set
   - name: "claude-code"
     description: "Test Claude Code CLI with MCP servers, tool usage (Read, Bash), and LLM API calls"
+    required_env_vars: ["ANTHROPIC_API_KEY"]
 
     mcpspy:
       # Enable LLM and tool monitoring to capture Anthropic API calls and tool usage from Claude Code

--- a/tests/e2e_config.yaml
+++ b/tests/e2e_config.yaml
@@ -101,10 +101,10 @@ scenarios:
         max: 30
 
   # Claude Code CLI scenario - comprehensive test for MCP, tools, and LLM
-  # This test requires ANTHROPIC_API_KEY environment variable to be set
+  # This test requires CLAUDE_CODE_OAUTH_TOKEN environment variable to be set
   - name: "claude-code"
     description: "Test Claude Code CLI with MCP servers, tool usage (Read, Bash), and LLM API calls"
-    required_env_vars: ["ANTHROPIC_API_KEY"]
+    required_env_vars: ["CLAUDE_CODE_OAUTH_TOKEN"]
 
     mcpspy:
       # Enable LLM and tool monitoring to capture Anthropic API calls and tool usage from Claude Code


### PR DESCRIPTION
## Summary
- Add missing `required_env_vars` configuration to e2e test scenarios that depend on API keys
- Scenarios now gracefully skip instead of failing when running on forked PRs where secrets are not available
- Fixes: `claude-code`, `tools-claude-code`, and `tools-gemini-cli` scenarios

## Test plan
- [ ] Verify CI passes on this PR (scenarios should skip gracefully)
- [ ] Verify forked PRs no longer fail due to missing API keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)