### PR TITLE
refactor(tests): consolidate tools scenarios into claude-code and gemini-cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -254,16 +254,6 @@ test-scenario-gemini-cli: test-e2e-setup ## Run Gemini CLI scenario (no MCPSpy, 
 	@echo "Running Gemini CLI scenario..."
 	$(call run-scenario,gemini-cli)
 
-.PHONY: test-scenario-tools-claudecode
-test-scenario-tools-claudecode: test-e2e-setup ## Run Claude Code tool usage scenario (no MCPSpy)
-	@echo "Running Claude Code tool usage scenario..."
-	$(call run-scenario,tools-claude-code)
-
-.PHONY: test-scenario-tools-gemini-cli
-test-scenario-tools-gemini-cli: test-e2e-setup ## Run Gemini CLI tool usage scenario (no MCPSpy, requires GEMINI_API_KEY)
-	@echo "Running Gemini CLI tool usage scenario..."
-	$(call run-scenario,tools-gemini-cli)
-
 # =============================================================================
 ##@ E2E Tests (with MCPSpy)
 # =============================================================================
@@ -302,16 +292,6 @@ test-e2e-security: build test-e2e-setup ## Run e2e test for security (requires H
 test-e2e-gemini-cli: build test-e2e-setup ## Run e2e test for Gemini CLI (requires GEMINI_API_KEY)
 	@echo "Running Gemini CLI e2e test..."
 	$(call run-e2e,gemini-cli)
-
-.PHONY: test-e2e-tools-claudecode
-test-e2e-tools-claudecode: build test-e2e-setup ## Run e2e test for Claude Code tool usage
-	@echo "Running Claude Code tool usage e2e test..."
-	$(call run-e2e,tools-claude-code)
-
-.PHONY: test-e2e-tools-gemini-cli
-test-e2e-tools-gemini-cli: build test-e2e-setup ## Run e2e test for Gemini CLI tool usage (requires GEMINI_API_KEY)
-	@echo "Running Gemini CLI tool usage e2e test..."
-	$(call run-e2e,tools-gemini-cli)
 
 .PHONY: test-e2e
 test-e2e: build test-e2e-setup ## Run all e2e test scenarios

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -23,10 +23,8 @@ make test-scenario-https          # HTTPS transport
 make test-scenario-security       # Security/injection test
 make test-scenario-llm-anthropic  # Anthropic LLM API test
 make test-scenario-llm-gemini     # Gemini LLM API test
-make test-scenario-claudecode         # Claude Code test
-make test-scenario-gemini-cli         # Gemini CLI test
-make test-scenario-tools-claudecode   # Claude Code tool usage test
-make test-scenario-tools-gemini-cli   # Gemini CLI tool usage test
+make test-scenario-claudecode         # Claude Code test (MCP + LLM + Tools)
+make test-scenario-gemini-cli         # Gemini CLI test (MCP + LLM + Tools)
 ```
 
 ### Run Security/Prompt Injection E2E Test
@@ -57,22 +55,6 @@ Requires `GEMINI_API_KEY` environment variable:
 
 ```bash
 GEMINI_API_KEY=your_api_key make test-e2e-gemini-cli
-```
-
-### Run Tool Usage E2E Tests
-
-Tool usage tests verify that tool invocations (CALL) and results (RSLT) are captured when using the `--tools` flag.
-
-**Claude Code Tool Usage:**
-
-```bash
-make test-e2e-tools-claudecode
-```
-
-**Gemini CLI Tool Usage** (requires `GEMINI_API_KEY`):
-
-```bash
-GEMINI_API_KEY=your_api_key make test-e2e-tools-gemini-cli
 ```
 
 ### Update Expected Outputs
@@ -183,7 +165,10 @@ python tests/e2e_test.py --config tests/e2e_config.yaml --verbose
 - MCP server initialization (filesystem and deepwiki HTTP servers)
 - Claude Code tool usage (Read, Bash tools)
 - LLM API calls (Anthropic API requests/responses)
+- Tool invocation events (CALL) and tool result events (RSLT)
 - Predictable tool execution with known inputs/outputs
+
+**MCPSpy flags:** `--llm --tools`
 
 **Test data:**
 
@@ -197,6 +182,7 @@ python tests/e2e_test.py --config tests/e2e_config.yaml --verbose
 - MCP server initialization (filesystem and deepwiki HTTP servers)
 - Gemini CLI tool usage (Read, Bash tools)
 - LLM API calls (Gemini API requests/responses)
+- Tool invocation events (CALL) and tool result events (RSLT)
 - Predictable tool execution with known inputs/outputs
 
 **Requirements:**
@@ -204,47 +190,11 @@ python tests/e2e_test.py --config tests/e2e_config.yaml --verbose
 - `GEMINI_API_KEY` environment variable with valid Gemini API key
 - Gemini CLI installed (via `npx @google/gemini-cli`)
 
+**MCPSpy flags:** `--llm --tools`
+
 **Test data:**
 
 - `tests/test_tool_data.txt` - Test file with known content for Read tool testing
-- `tests/.gemini/settings.json` - MCP server configuration
-
-### tools-claude-code
-
-**What it tests:**
-
-- Tool usage monitoring with `--tools` flag
-- Tool invocation events (CALL) when Claude Code requests tool use
-- Tool result events (RSLT) when tool execution completes
-- Tool name extraction (Read, Bash)
-- Tool ID correlation between invocations and results
-
-**MCPSpy flags:** `--tools`
-
-**Test data:**
-
-- `tests/test_tool_data.txt` - Test file for Read tool testing
-- `tests/claude_config.json` - MCP server configuration
-
-### tools-gemini-cli
-
-**What it tests:**
-
-- Tool usage monitoring with `--tools` flag
-- Tool invocation events (CALL) when Gemini CLI requests tool use
-- Tool result events (RSLT) when tool execution completes
-- Tool name extraction (Read, Bash)
-- Tool ID correlation between invocations and results
-
-**Requirements:**
-
-- `GEMINI_API_KEY` environment variable with valid Gemini API key
-
-**MCPSpy flags:** `--tools`
-
-**Test data:**
-
-- `tests/test_tool_data.txt` - Test file for Read tool testing
 - `tests/.gemini/settings.json` - MCP server configuration
 
 ## File Reference

--- a/tests/e2e_config.yaml
+++ b/tests/e2e_config.yaml
@@ -105,8 +105,8 @@ scenarios:
     description: "Test Claude Code CLI with MCP servers, tool usage (Read, Bash), and LLM API calls"
 
     mcpspy:
-      # Enable LLM monitoring to capture Anthropic API calls from Claude Code
-      flags: ["--tui=false", "--log-level", "trace", "--llm"]
+      # Enable LLM and tool monitoring to capture Anthropic API calls and tool usage from Claude Code
+      flags: ["--tui=false", "--log-level", "trace", "--llm", "--tools"]
 
     traffic:
       # Run Claude Code with explicit tool usage instructions
@@ -114,6 +114,7 @@ scenarios:
       # 1. MCP server initialization (filesystem and deepwiki servers)
       # 2. Tool usage (Read to read test file, Bash to run echo)
       # 3. LLM API calls (Claude processing the prompt and generating response)
+      # 4. Tool invocation/result events captured by --tools flag
       # Using --print flag for non-interactive output
       command:
         [
@@ -121,7 +122,7 @@ scenarios:
           "-c",
           "npx -y @anthropic-ai/claude-code --print -p 'Execute these exact steps in order: 1) Use the Read tool to read tests/test_tool_data.txt and report its content. 2) Use Bash to run: echo MCPSPY-TEST-COMPLETE. Report both results concisely.' --strict-mcp-config --mcp-config tests/claude_config.json 2>&1",
         ]
-      timeout_seconds: 30
+      timeout_seconds: 60
       # Wait for tool execution and LLM response to complete
       post_traffic_wait_seconds: 5
 
@@ -136,8 +137,8 @@ scenarios:
     required_env_vars: ["GEMINI_API_KEY"]
 
     mcpspy:
-      # Enable LLM monitoring to capture Gemini API calls
-      flags: ["--tui=false", "--log-level", "trace", "--llm"]
+      # Enable LLM and tool monitoring to capture Gemini API calls and tool usage
+      flags: ["--tui=false", "--log-level", "trace", "--llm", "--tools"]
 
     traffic:
       # Run Gemini CLI with explicit tool usage instructions
@@ -145,6 +146,7 @@ scenarios:
       # 1. MCP server initialization (filesystem and deepwiki servers)
       # 2. Tool usage (Read to read test file, Bash to run echo)
       # 3. LLM API calls (Gemini processing the prompt and generating response)
+      # 4. Tool invocation/result events captured by --tools flag
       # Using --yolo for auto-approval (no --sandbox to avoid namespace isolation issues with eBPF)
       # The tests/.gemini/settings.json contains MCP server configuration
       command:
@@ -231,74 +233,6 @@ scenarios:
           - "root\\[\\d+\\]\\['pid'\\]"
           # Exclude raw JSON field (contains full API payload)
           - "root\\[\\d+\\]\\['raw_json'\\]"
-
-  # Tool usage monitoring scenario (Claude Code)
-  # Tests that tool invocations and results are captured when using --tools flag
-  - name: "tools-claude-code"
-    description: "Test tool usage monitoring with Claude Code (tool invocations and results)"
-
-    mcpspy:
-      # Enable tool monitoring to capture tool usage events from Claude Code
-      flags: ["--tui=false", "--log-level", "trace", "--tools"]
-
-    traffic:
-      # Run Claude Code with explicit tool usage instructions
-      # This triggers tool invocations (Read, Bash) and their results
-      command:
-        [
-          "bash",
-          "-c",
-          "npx -y @anthropic-ai/claude-code --print -p 'Execute these exact steps in order: 1) Use the Read tool to read tests/test_tool_data.txt and report its content. 2) Use Bash to run: echo MCPSPY-TEST-COMPLETE. Report both results concisely.' --strict-mcp-config --mcp-config tests/claude_config.json 2>&1",
-        ]
-      timeout_seconds: 60
-      # Wait for tool execution and results to complete
-      post_traffic_wait_seconds: 5
-
-    validation:
-      # Validate message count only - the test captures MCP events from servers
-      # plus tool usage events (invocation/result) from the LLM API.
-      # Minimum 4 tool usage events expected: 2 invocations (Read, Bash) + 2 results
-      message_count:
-        min: 4
-
-  # Tool usage monitoring scenario (Gemini CLI)
-  # Tests that tool invocations and results are captured when using --tools flag
-  # This test requires GEMINI_API_KEY environment variable to be set
-  - name: "tools-gemini-cli"
-    description: "Test tool usage monitoring with Gemini CLI (tool invocations and results)"
-
-    pre_commands:
-      - command:
-          [
-            "bash",
-            "-c",
-            'if [ -z "$GEMINI_API_KEY" ]; then echo ''ERROR: GEMINI_API_KEY environment variable is required''; exit 1; fi',
-          ]
-        timeout_seconds: 5
-
-    mcpspy:
-      # Enable tool monitoring to capture tool usage events from Gemini CLI
-      flags: ["--tui=false", "--log-level", "trace", "--tools"]
-
-    traffic:
-      # Run Gemini CLI with explicit tool usage instructions
-      # This triggers tool invocations (Read, Bash) and their results
-      command:
-        [
-          "bash",
-          "-c",
-          "cd tests && npx -y @google/gemini-cli --yolo -o text 'Execute these exact steps in order: 1) Use the Read tool to read test_tool_data.txt and report its content. 2) Use Bash to run: echo MCPSPY-TEST-COMPLETE. Report both results concisely.' 2>&1",
-        ]
-      timeout_seconds: 120
-      # Wait for tool execution and results to complete
-      post_traffic_wait_seconds: 5
-
-    validation:
-      # Validate message count only - the test captures MCP events from servers
-      # plus tool usage events (invocation/result) from the LLM API.
-      # Minimum 4 tool usage events expected: 2 invocations (Read, Bash) + 2 results
-      message_count:
-        min: 4
 
   # Security/Prompt Injection detection scenario
   # This test requires HF_TOKEN environment variable to be set


### PR DESCRIPTION
## Summary
- Consolidate tools-claude-code and tools-gemini-cli scenarios into the main claude-code and gemini-cli scenarios
- Both scenarios now test MCP, LLM API monitoring, and tool usage tracking comprehensively with `--llm --tools` flags
- Remove redundant test targets from Makefile and update documentation

## Test plan
- [x] Verify unit tests pass (`make test-unit`)
- [x] Verify stdio scenario passes (`make test-scenario-stdio`)
- [x] Verify claude-code scenario passes (`make test-scenario-claudecode`)
- [ ] Run full e2e tests with MCPSpy (requires sudo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)