### PR TITLE
feat(cli): add --headers flag to debug command for HTTP header display

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -100,8 +100,11 @@ sudo ./mcpspy debug --comm claude
 # Debug HTTP parsing issues
 sudo ./mcpspy debug --events tls_recv,http_request,http_response --payload
 
-# Combine filters
-sudo ./mcpspy debug --events mcp_message,http_request --pid 12345 --payload
+# Show HTTP headers
+sudo ./mcpspy debug --events http_request,http_response --headers
+
+# Combine filters with headers
+sudo ./mcpspy debug --events http_request,http_response --pid 12345 --headers --payload
 ```
 
 **Available event types:**
@@ -114,6 +117,7 @@ sudo ./mcpspy debug --events mcp_message,http_request --pid 12345 --payload
 - `--comm, -c`: Filter by process name (substring match)
 - `--host`: Filter by URL regex (matches against host+path, e.g., `api\.anthropic\.com/v1/messages`)
 - `--payload`: Show payload/buffer data for events
+- `--headers`: Show HTTP headers for HTTP events
 
 ## Testing
 

--- a/cmd/mcpspy/debug.go
+++ b/cmd/mcpspy/debug.go
@@ -29,6 +29,7 @@ var (
 	debugComm        string   // Filter by process name (comm)
 	debugHost        string   // Filter by host (regex)
 	debugShowPayload bool     // Show payload/buffer data
+	debugShowHeaders bool     // Show HTTP headers
 )
 
 func newDebugCmd() *cobra.Command {
@@ -78,11 +79,14 @@ Examples:
   # Debug HTTP parsing issues
   sudo mcpspy debug --events tls_recv,http_request,http_response --payload
 
+  # Show HTTP headers
+  sudo mcpspy debug --events http_request,http_response --headers
+
   # Filter by host (regex)
   sudo mcpspy debug --host "api\.anthropic\.com" --payload
 
-  # Combine filters
-  sudo mcpspy debug --events mcp_message,http_request --pid 12345 --payload`,
+  # Combine filters with headers
+  sudo mcpspy debug --events http_request,http_response --pid 12345 --headers --payload`,
 		RunE:         runDebug,
 		SilenceUsage: true,
 	}
@@ -98,6 +102,8 @@ Examples:
 		"Filter by host (regex pattern, e.g., 'api\\.anthropic\\.com')")
 	debugCmd.Flags().BoolVar(&debugShowPayload, "payload", false,
 		"Show payload/buffer data for events")
+	debugCmd.Flags().BoolVar(&debugShowHeaders, "headers", false,
+		"Show HTTP headers for HTTP events")
 
 	return debugCmd
 }
@@ -116,6 +122,7 @@ func runDebug(cmd *cobra.Command, args []string) error {
 		Comm:        debugComm,
 		Host:        debugHost,
 		ShowPayload: debugShowPayload,
+		ShowHeaders: debugShowHeaders,
 	}
 
 	// Fetch current mount namespace


### PR DESCRIPTION
## Summary

- Add `--headers` flag to `mcpspy debug` command for displaying HTTP headers
- Headers are shown for `http_request` and `http_response` events
- Formatted output with colored key names for better readability

## Changes

- `pkg/output/debug_display.go`: Add `ShowHeaders` config field and `printHeaders()` method
- `cmd/mcpspy/debug.go`: Add `--headers` CLI flag and filter configuration
- `.claude/CLAUDE.md`: Update documentation with usage examples

## Usage Examples

```bash
# Show HTTP headers
sudo mcpspy debug --events http_request,http_response --headers

# Combine with payload display
sudo mcpspy debug --events http_request,http_response --headers --payload

# Filter by host and show headers
sudo mcpspy debug --host "api\.anthropic\.com" --headers
```

## Test plan

- [x] Unit tests pass
- [x] Build succeeds
- [x] Flag shows in help text
- [x] Headers display correctly for HTTP events

🤖 Generated with [Claude Code](https://claude.com/claude-code)